### PR TITLE
BIC-161 # reload during init if core deps fail

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,7 +90,7 @@ module.exports = function (grunt) {
             feature: '../node_modules/amd-feature/feature',
             pollUntil: '../node_modules/poll-until/poll-until',
             BlinkGap: '../node_modules/blinkgap-utils/BMP.BlinkGap',
-            geolocation: '../node_modules/geolocation/geolocation',
+            '@blinkmobile/geolocation': '../node_modules/@blinkmobile/geolocation/geolocation',
             'is-indexeddb-reliable': '../node_modules/is-indexeddb-reliable/dist/index',
             text: '../node_modules/text/text',
             domReady: '../node_modules/domReady/domReady',

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "formsversion": "3.3.3",
   "main": "Gruntfile.js",
   "dependencies": {
+    "@blinkmobile/geolocation": "1.0.0",
     "almond": "0.3.1",
     "amd-feature": "jensarps/AMD-feature#295cb395fe",
     "blinkgap-utils": "blinkmobile/blinkgap-utils#500774457d",
     "domReady": "requirejs/domReady#449478e133",
-    "geolocation": "git://github.com/blinkmobile/geolocation#v1.0.0",
     "is-indexeddb-reliable": "blinkmobile/is-indexeddb-reliable#v1.0.1",
     "node-uuid": "1.4.3",
     "offlineLogin": "blinkmobile/offlineLogin#v1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "glob": "^5.0.10",
     "grunt": "~0.4",
     "grunt-cli": "^0.1.13",
-    "grunt-concurrent": "~1.0",
+    "grunt-concurrent": "~2.0",
     "grunt-contrib-copy": "~0.8",
     "grunt-contrib-requirejs": "~0.4",
     "grunt-contrib-uglify": "^0.9.1",

--- a/src/bic/view-interaction.js
+++ b/src/bic/view-interaction.js
@@ -7,7 +7,7 @@ define(function (require) {
     var $ = require('jquery');
     var _ = require('underscore');
     var Backbone = require('backbone');
-    var geolocation = require('geolocation');
+    var geolocation = require('@blinkmobile/geolocation');
     var Mustache = require('mustache');
     var Promise = require('feature!promises');
 

--- a/src/buildFiles/files/index.mustache
+++ b/src/buildFiles/files/index.mustache
@@ -38,5 +38,40 @@
   <noscript>You currently have JavaScript disabled. This application requires JavaScript to work correctly.</noscript>
   <div data-role="page" id="temp">Loading, please wait.</div>
   {{&answerSpace.scripts_html}}
+  <script>
+  (function () {
+    var CORE_DEPS = ['jquery', 'jquerymobile', 'backbone', 'pouchdb'];
+    var logError = function (err) {
+      if (window.console && window.console.error) {
+        window.console.error(err);
+      }
+    };
+
+    // we don't support IE8, we use `Array#forEach()` and  `Array#indexOf()`
+    if (!Array || !Array.prototype || !Array.prototype.forEach || !Array.prototype.indexOf) {
+      logError(new Error('Array#indexOf() not implemented'));
+      location.assign('http://outdatedbrowser.com/');
+    }
+
+    // double-check that we have Require.js at least
+    if (!window.define || !window.require || !window.requirejs) {
+      logError(new Error('Require.js not loaded'));
+      location.reload();
+    }
+
+    // if we have a module timeout, and it is a core module, reload immediately
+    requirejs.onError = function (err) {
+      if (err.requireType === 'timeout') {
+        CORE_DEPS.forEach(function (dep) {
+          if (err.requireModules.indexOf(dep) !== -1) {
+            logError(new Error('Require.js could not load: ' + dep));
+            location.reload();
+          }
+        });
+      }
+      throw err;
+    };
+  }());
+  </script>
 </body>
 </html>

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -9,7 +9,7 @@ require.config({
   paths: {
     'is-indexeddb-reliable': '/node_modules/is-indexeddb-reliable/dist/index',
     feature: '/node_modules/amd-feature/feature',
-    geolocation: '/node_modules/geolocation/geolocation',
+    '@blinkmobile/geolocation': '/node_modules/@blinkmobile/geolocation/geolocation',
     Squire: '/node_modules/squirejs/src/Squire',
     pollUntil: '/node_modules/poll-until/poll-until',
     mustache: '/node_modules/mustache/mustache',


### PR DESCRIPTION
We already have a initialisation watchdog, but that is created by the BIC and requires the BIC.

This PR introduces an earlier Require.js watchdog that functions even when the BIC is broken. It requires BMP v2.25.0 and up, due to implementation in the initial HTML template.

Sequence:
1. if missing basic `Array` methods that the watchdog uses (e.g. in IE8) then redirect to http://outdatedbrowser.com/
2. if Require.js itself failed to load, then reload
3. if Require.js fails to load a core dependency (e.g. jQuery, jQuery Mobile, Backbone, PouchDB), then reload

In my testing in Chrome Dev. Tools simulating a Regular 2G connection, this recovers from the typical module timeouts that occurs as expected. Note that caching must be enabled for recovery, otherwise we get into a timeout loop.

I did not adjust the `waitSeconds` parameter for Require.js, as I think the 7 seconds default combined with the watchdog is a sufficient compromise. However, I can increase the timeout if recommended.

The minor tweak accompanying BIC-161 in this PR is using our [geolocation](https://www.npmjs.com/package/@blinkmobile/geolocation) module directly via NPM, instead of as a git reference. This further helps to lock down our dependencies.