### PR TITLE
BIC-181 # load jQuery _before_ `BlinkGap.whenReady()`

### DIFF
--- a/src/bic/promise-blinkgap.js
+++ b/src/bic/promise-blinkgap.js
@@ -9,6 +9,8 @@ define(function () {
 
   var realPromise; // not jQuery.Deferred, yuck!
 
+  require('jquery'); // quick fix, .whenReady() need jQuery to be loaded
+
   if (window.BMP && window.BMP.BlinkGap && window.BMP.BlinkGap.isHere && window.BMP.BlinkGap.isHere()) {
 
     // convert jQuery.Deferred to an ES6 Promise so we can safely chain it


### PR DESCRIPTION
This was killing the native iOS and Android apps.