### PR TITLE
BIC-179 # turning Forms pages over-enhances elements

### DIFF
--- a/src/bic/view-form-controls.js
+++ b/src/bic/view-form-controls.js
@@ -92,8 +92,7 @@ define(function (require) {
       }
 
       view.$el.html(Mustache.render(view.constructor.template, options));
-      $.mobile.activePage.trigger('pagecreate');
-
+      view.$el.trigger('create');
       return view;
     },
 


### PR DESCRIPTION
- instead of page create, use 'create' on element, which will only enhance child elements