### PR TITLE
BIC-187 # fix post-restructure issues breaking Android 4.3, iOS 7, IE 10-11

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@jokeyrhyme/appcache": "^1.0",
     "chai": "~3.0",
+    "eslint": "^0.24.0",
     "glob": "^5.0.10",
     "grunt": "~0.4",
     "grunt-cli": "^0.1.13",

--- a/src/bic.js
+++ b/src/bic.js
@@ -5,6 +5,7 @@ define(function (require) {
   // foreign modules
 
   var $ = require('jquery');
+  var Promise = require('feature!promises');
 
   require('feature!es5');
   require('BlinkGap');
@@ -22,6 +23,9 @@ define(function (require) {
   require('bic/backbone-fix');
 
   // this module
+
+  // poly-fill Promise if missing (needed for Forms, etc)
+  window.Promise = window.Promise || Promise;
 
   function start () {
     // AJAX Default Options

--- a/src/bic/form-expressions.js
+++ b/src/bic/form-expressions.js
@@ -9,6 +9,7 @@ define(function (require) {
   // foreign modules
 
   var $ = require('jquery');
+  var Promise = require('feature!promises');
   require('jquerymobile');
   require('BlinkForms');
 

--- a/src/bic/model-application.js
+++ b/src/bic/model-application.js
@@ -187,6 +187,10 @@ define(function (require) {
                 }
               ),
               function (model) {
+                if (!app.hasStorage()) {
+                  app.interactions.remove(model);
+                  return Promise.resolve();
+                }
                 return new Promise(function (resolve, reject) {
                   model.destroy({
                     success: resolve,
@@ -201,6 +205,9 @@ define(function (require) {
           function () {
             app.forms.whenUpdated();
             app.retrieveDataSuitcasesForInteractions();
+            if (!app.hasStorage()) {
+              return Promise.resolve();
+            }
             return app.interactions.save();
           }
         );

--- a/src/bic/router.js
+++ b/src/bic/router.js
@@ -7,6 +7,7 @@ define(function (require) {
   var _ = require('underscore');
   var Backbone = require('backbone');
   var Modernizr = require('modernizr');
+  var Promise = require('feature!promises');
 
   // local modules
 

--- a/src/bic/router.js
+++ b/src/bic/router.js
@@ -94,13 +94,15 @@ define(function (require) {
         .then(function () {
           return app.populate();
         })
-        .then(null, function () {
+        .then(null, function (err) {
+          window.console.error(err);
           return;
         })
         .then(function () {
           return app.initialRender();
         })
         .then(null, function (err) {
+          window.console.error(err);
           throw err;
         });
     },


### PR DESCRIPTION
- all modules that use `Promise` now explicitly `require('feature!promises');`
- the main BIC module defines `window.Promise` if it is undefined
- skip a few persistent steps during initialisation if we don't have persistent storage