### PR TITLE
BIC-180 # forms pagination controls become out of sync vs API goto

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,8 +7,8 @@
 /.idea
 
 # output files
+build
 dist
-/js
 versions
 tests/support/bic.js
 

--- a/src/bic/view-form-controls.js
+++ b/src/bic/view-form-controls.js
@@ -91,61 +91,57 @@ define(function (require) {
         }
       }
 
+      Forms.current.get('pages').once('change', function () {
+        Forms.once('pageInjected', function() {
+          view.render();
+        });
+      });
+
       view.$el.html(Mustache.render(view.constructor.template, options));
       view.$el.trigger('create');
       return view;
     },
 
     firstFormPage: function () {
-      var view, index;
+      var index;
 
-      view = this;
       index = Forms.current.get('pages').current.index();
 
       if (index > 0) {
         Forms.current.get('pages').goto(0);
-        view.render();
       }
     },
 
     lastFormPage: function () {
-      var view, index, len;
+      var index, len;
 
-      view = this;
       len = Forms.current.get('pages').length;
       index = Forms.current.get('pages').current.index();
 
       //only move and render if required
       if (index < len - 1) {
         Forms.current.get('pages').goto(len - 1);
-        view.render();
       }
     },
 
     nextFormPage: function () {
-      var view, index;
+      var index;
 
-      view = this;
       index = Forms.current.get('pages').current.index();
 
       if (index < Forms.current.get('pages').length - 1) {
         Forms.current.get('pages').goto(index + 1);
       }
-
-      view.render();
     },
 
     previousFormPage: function () {
-      var view, index;
+      var index;
 
-      view = this;
       index = Forms.current.get('pages').current.index();
 
       if (index > 0) {
         Forms.current.get('pages').goto(index - 1);
       }
-
-      view.render();
     },
 
     formLeave: function (userAction) {

--- a/tests/unit/view-form-controls.js
+++ b/tests/unit/view-form-controls.js
@@ -13,9 +13,9 @@ define([
       pageObject = {
         length: 4,
         current: {
-          "index": function() { return pageid; }
+          'index': function() { return pageid; }
         },
-        "goto": function (num) {
+        'goto': function (num) {
           pageid = num;
         }
       };
@@ -86,6 +86,72 @@ define([
       View.should.be.an.instanceOf(Function);
     });
 
+    describe('pages collection', function () {
+      var gotoSpy;
+      var indexSpy;
+      var view;
+
+      beforeEach(function (done) {
+        //setup spys
+        indexSpy = sinon.spy(pageObject.current, 'index');
+        gotoSpy = sinon.spy(pageObject, 'goto');
+
+        injector.require(['bic/model-application'], function (app) {
+          view = new View({ model: app});
+          done();
+        });
+      });
+
+      afterEach(function () {
+        //remove spy
+        pageObject.current.index.restore();
+        pageObject.goto.restore();
+      });
+
+      it('nextFormPage', function() {
+        //move to next page
+        view.nextFormPage();
+        assert.equal(indexSpy.callCount, 1);
+        assert.equal(gotoSpy.callCount, 1);
+        assert.equal(pageid, 1);
+      });
+
+      it('firstFormPage', function() {
+        //move to first page
+        view.firstFormPage();
+        assert.equal(indexSpy.callCount, 1);
+        assert.equal(gotoSpy.callCount, 1);
+        assert.equal(pageid, 0);
+
+        //should not re-render the page because already on first page
+        view.firstFormPage();
+        assert.equal(indexSpy.callCount, 2);
+        assert.equal(gotoSpy.callCount, 1);
+      });
+
+      it('lastFormPage', function() {
+        //move to last page
+        view.lastFormPage();
+        assert.equal(indexSpy.callCount, 1);
+        assert.equal(gotoSpy.callCount, 1);
+        assert.equal(pageid, pageObject.length - 1);
+
+        //should not re-render the page because already on last page
+        view.lastFormPage();
+        assert.equal(indexSpy.callCount, 2);
+        assert.equal(gotoSpy.callCount, 1);
+      });
+
+      it('previousFormPage', function() {
+        //move to second last page
+        view.previousFormPage();
+        assert.equal(indexSpy.callCount, 1);
+        assert.equal(gotoSpy.callCount, 1);
+        assert.equal(pageid, pageObject.length - 2);
+      });
+
+    });
+
     describe('addToQueue', function () {
       var view, processQueueStub;
 
@@ -111,6 +177,7 @@ define([
 
         });
       });
+
       it('functions on view', function () {
         expect(view.formSubmit).to.be.an.instanceOf(Function);
         expect(view.formClose).to.be.an.instanceOf(Function);
@@ -121,92 +188,6 @@ define([
         expect(view.formSave).to.be.an.instanceOf(Function);
         expect(view.formDiscard).to.be.an.instanceOf(Function);
         expect(view.addToQueue).to.be.an.instanceOf(Function);
-      });
-
-      it('nextFormPage test', function() {
-        var gotoSpy,
-          indexSpy;
-
-        //setup spys
-        indexSpy = sinon.spy(pageObject.current, "index");
-        gotoSpy = sinon.spy(pageObject, "goto");
-
-        //move to next page
-        view.nextFormPage();
-        assert.equal(indexSpy.callCount, 1);
-        assert.equal(gotoSpy.callCount, 1);
-        assert.equal(pageid, 1);
-
-        //remove spy
-        pageObject.current.index.restore();
-        pageObject.goto.restore();
-      });
-
-      it('firstFormPage test', function() {
-        var gotoSpy,
-          indexSpy;
-
-        //setup spys
-        indexSpy = sinon.spy(pageObject.current, "index");
-        gotoSpy = sinon.spy(pageObject, "goto");
-
-        //move to first page
-        view.firstFormPage();
-        assert.equal(indexSpy.callCount, 1);
-        assert.equal(gotoSpy.callCount, 1);
-        assert.equal(pageid, 0);
-
-        //should not re-render the page because already on first page
-        view.firstFormPage();
-        assert.equal(indexSpy.callCount, 2);
-        assert.equal(gotoSpy.callCount, 1);
-
-        //remove spy
-        pageObject.current.index.restore();
-        pageObject.goto.restore();
-      });
-
-      it('lastFormPage test', function() {
-        var gotoSpy,
-          indexSpy;
-
-        //setup spys
-        indexSpy = sinon.spy(pageObject.current, "index");
-        gotoSpy = sinon.spy(pageObject, "goto");
-
-        //move to last page
-        view.lastFormPage();
-        assert.equal(indexSpy.callCount, 1);
-        assert.equal(gotoSpy.callCount, 1);
-        assert.equal(pageid, pageObject.length - 1);
-
-        //should not re-render the page because already on last page
-        view.lastFormPage();
-        assert.equal(indexSpy.callCount, 2);
-        assert.equal(gotoSpy.callCount, 1);
-
-        //remove spy
-        pageObject.current.index.restore();
-        pageObject.goto.restore();
-      });
-
-      it('previousFormPage test', function() {
-        var gotoSpy,
-          indexSpy;
-
-        //setup spys
-        indexSpy = sinon.spy(pageObject.current, "index");
-        gotoSpy = sinon.spy(pageObject, "goto");
-
-        //move to second last page
-        view.previousFormPage();
-        assert.equal(indexSpy.callCount, 1);
-        assert.equal(gotoSpy.callCount, 1);
-        assert.equal(pageid, pageObject.length - 2);
-
-        //remove spy
-        pageObject.current.index.restore();
-        pageObject.goto.restore();
       });
 
       it('should add item with status Pending in pending queue', function (done) {

--- a/tests/unit/view-form-controls.js
+++ b/tests/unit/view-form-controls.js
@@ -15,7 +15,9 @@ define([
         current: {
           "index": function() { return pageid; }
         },
-        "goto": function (num) { pageid = num; }
+        "goto": function (num) {
+          pageid = num;
+        }
       };
 
     before(function (done) {
@@ -123,122 +125,88 @@ define([
 
       it('nextFormPage test', function() {
         var gotoSpy,
-          indexSpy,
-          renderSpy,
-          oldRender;
-
-        oldRender = view.render;
-        view.render = function() {};
+          indexSpy;
 
         //setup spys
         indexSpy = sinon.spy(pageObject.current, "index");
         gotoSpy = sinon.spy(pageObject, "goto");
-        renderSpy = sinon.spy(view, "render");
 
         //move to next page
         view.nextFormPage();
         assert.equal(indexSpy.callCount, 1);
         assert.equal(gotoSpy.callCount, 1);
-        assert.equal(renderSpy.callCount, 1);
         assert.equal(pageid, 1);
 
         //remove spy
         pageObject.current.index.restore();
         pageObject.goto.restore();
-        view.render = oldRender;
       });
 
       it('firstFormPage test', function() {
         var gotoSpy,
-          indexSpy,
-          renderSpy,
-          oldRender;
-
-        oldRender = view.render;
-        view.render = function() {};
+          indexSpy;
 
         //setup spys
         indexSpy = sinon.spy(pageObject.current, "index");
         gotoSpy = sinon.spy(pageObject, "goto");
-        renderSpy = sinon.spy(view, "render");
 
         //move to first page
         view.firstFormPage();
         assert.equal(indexSpy.callCount, 1);
         assert.equal(gotoSpy.callCount, 1);
-        assert.equal(renderSpy.callCount, 1);
         assert.equal(pageid, 0);
 
         //should not re-render the page because already on first page
         view.firstFormPage();
         assert.equal(indexSpy.callCount, 2);
         assert.equal(gotoSpy.callCount, 1);
-        assert.equal(renderSpy.callCount, 1);
 
         //remove spy
         pageObject.current.index.restore();
         pageObject.goto.restore();
-        view.render = oldRender;
       });
 
       it('lastFormPage test', function() {
         var gotoSpy,
-          indexSpy,
-          renderSpy,
-          oldRender;
-
-        oldRender = view.render;
-        view.render = function() {};
+          indexSpy;
 
         //setup spys
         indexSpy = sinon.spy(pageObject.current, "index");
         gotoSpy = sinon.spy(pageObject, "goto");
-        renderSpy = sinon.spy(view, "render");
 
         //move to last page
         view.lastFormPage();
         assert.equal(indexSpy.callCount, 1);
         assert.equal(gotoSpy.callCount, 1);
-        assert.equal(renderSpy.callCount, 1);
         assert.equal(pageid, pageObject.length - 1);
 
         //should not re-render the page because already on last page
         view.lastFormPage();
         assert.equal(indexSpy.callCount, 2);
         assert.equal(gotoSpy.callCount, 1);
-        assert.equal(renderSpy.callCount, 1);
 
         //remove spy
         pageObject.current.index.restore();
         pageObject.goto.restore();
-        view.render = oldRender;
       });
 
       it('previousFormPage test', function() {
         var gotoSpy,
-          indexSpy,
-          renderSpy,
-          oldRender;
-
-        oldRender = view.render;
-        view.render = function() {};
+          indexSpy;
 
         //setup spys
         indexSpy = sinon.spy(pageObject.current, "index");
         gotoSpy = sinon.spy(pageObject, "goto");
-        renderSpy = sinon.spy(view, "render");
 
         //move to second last page
         view.previousFormPage();
         assert.equal(indexSpy.callCount, 1);
         assert.equal(gotoSpy.callCount, 1);
-        assert.equal(renderSpy.callCount, 1);
         assert.equal(pageid, pageObject.length - 2);
 
         //remove spy
         pageObject.current.index.restore();
         pageObject.goto.restore();
-        view.render = oldRender;
       });
 
       it('should add item with status Pending in pending queue', function (done) {


### PR DESCRIPTION
- first, last, next, previous: just changes the page
-- leaves everything else on page change event
-- once page change happens and page injected triggers
- bind event once, so every time render gets called, he removes the event handler and adds it back again
- so api's and buttons will use same behaviour
- removed checks in test for render function calls