### PR TITLE
BIC-190 # random init failures in Windows app

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -89,6 +89,7 @@ module.exports = function (grunt) {
             BlinkGap: '../node_modules/blinkgap-utils/BMP.BlinkGap',
             '@blinkmobile/geolocation': '../node_modules/@blinkmobile/geolocation/geolocation',
             'is-indexeddb-reliable': '../node_modules/is-indexeddb-reliable/dist/index',
+            '@jokeyrhyme/deadline': '../node_modules/@jokeyrhyme/deadline/dist/index',
             text: '../node_modules/text/text',
             domReady: '../node_modules/domReady/domReady',
             uuid: '../node_modules/node-uuid/uuid',

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,56 @@
+# BIC: Console Logging
+
+For convenience, we provide a central logging API that proxies calls to the
+global `console` object (if available).
+
+```js
+require(['bic'], function () {
+  // now the code for the BIC is ready
+  // the global `BMP.console` object provides access to our logging API
+  window.BMP.console.log('hello world');
+});
+```
+
+
+## API
+
+
+### `BMP.console.debug(msg)`
+### `BMP.console.info(msg)`
+### `BMP.console.log(msg)`
+### `BMP.console.warn(msg)`
+### `BMP.console.error(msg)`
+
+These methods are proxies to the same methods on the real `console` object. It
+is safe to call our methods even when the real methods are not available.
+
+
+### `BMP.console.LOG_LEVELS`
+
+- @const {`String`[]}
+
+This is an enumeration of the names of the logging methods, ranked in order from
+most noisy to most important.
+
+
+### `BMP.console.logLevel`
+
+- @type {`Number`}
+- @default 2
+
+This is the index of the least important kind of message that you'd like to
+track, based on its position in the `BMP.console.LOG_LEVELS` Array. The default
+is to output "log", "warn" and "error" messages, but drop "info" and "debug"
+messages.
+
+
+### `BMP.console.logElement`
+
+- @type {`?HTMLUListElement`}
+
+We expect this to either be `null` or a `<ul></ul>` DOM Element. When this is
+a DOM Element, we automatically append new `<li></li>` DOM Elements for each new
+message passed to our logging API.
+
+This is primarily provided to ease debugging in environments where log output is
+otherwise difficult to access.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function (config) {
       { pattern: 'node_modules/chai/chai.js', included: false },
       { pattern: 'node_modules/is-indexeddb-reliable/dist/index.js', included: false },
       { pattern: 'node_modules/amd-feature/feature.js', included: false },
+      { pattern: 'node_modules/@jokeyrhyme/deadline/dist/index.js', included: false },
       { pattern: 'node_modules/@blinkmobile/geolocation/geolocation.js', included: false },
       { pattern: 'node_modules/squirejs/src/Squire.js', included: false },
       { pattern: 'node_modules/poll-until/poll-until.js', included: false },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "tape-chai": "^1.1"
   },
   "scripts": {
+    "build": "grunt build",
     "test": "gulp test && grunt test"
   },
   "license": "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "Gruntfile.js",
   "dependencies": {
     "@blinkmobile/geolocation": "1.0.0",
+    "@jokeyrhyme/deadline": "1.0.0",
     "amd-feature": "jensarps/AMD-feature#295cb395fe",
     "blinkgap-utils": "blinkmobile/blinkgap-utils#500774457d",
     "domReady": "requirejs/domReady#449478e133",

--- a/src/bic.js
+++ b/src/bic.js
@@ -2,8 +2,6 @@
 define(function (require) {
   'use strict';
 
-  window.console.log('bic.js');
-
   // foreign modules
 
   var $ = require('jquery');
@@ -18,6 +16,7 @@ define(function (require) {
   // local modules
 
   var app = require('bic/model/application');
+  var c = require('bic/console');
   var whenBlinkGapReady = require('bic/promise-blinkgap');
 
   require('bic/auth');
@@ -26,7 +25,7 @@ define(function (require) {
   // this module
 
   function start () {
-    window.console.log('bic.js: start()');
+    c.log('bic.js: start()');
     // AJAX Default Options
     $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
       jqXHR.setRequestHeader('X-Blink-Config',

--- a/src/bic.js
+++ b/src/bic.js
@@ -2,6 +2,8 @@
 define(function (require) {
   'use strict';
 
+  window.console.log('bic.js');
+
   // foreign modules
 
   var $ = require('jquery');
@@ -28,6 +30,7 @@ define(function (require) {
   window.Promise = window.Promise || Promise;
 
   function start () {
+    window.console.log('bic.js: start()');
     // AJAX Default Options
     $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
       jqXHR.setRequestHeader('X-Blink-Config',

--- a/src/bic.js
+++ b/src/bic.js
@@ -7,7 +7,6 @@ define(function (require) {
   // foreign modules
 
   var $ = require('jquery');
-  var Promise = require('feature!promises');
 
   require('feature!es5');
   require('BlinkGap');
@@ -25,9 +24,6 @@ define(function (require) {
   require('bic/backbone-fix');
 
   // this module
-
-  // poly-fill Promise if missing (needed for Forms, etc)
-  window.Promise = window.Promise || Promise;
 
   function start () {
     window.console.log('bic.js: start()');

--- a/src/bic.js
+++ b/src/bic.js
@@ -16,16 +16,17 @@ define(function (require) {
   // local modules
 
   var app = require('bic/model/application');
-  var c = require('bic/console');
   var whenBlinkGapReady = require('bic/promise-blinkgap');
 
   require('bic/auth');
   require('bic/backbone-fix');
+  require('bic/debug-jquery');
+  require('bic/fix-animation');
 
   // this module
 
-  function start () {
-    c.log('bic.js: start()');
+  // delay the app for Cordova if present
+  whenBlinkGapReady.then(function () {
     // AJAX Default Options
     $.ajaxPrefilter(function (options, originalOptions, jqXHR) {
       jqXHR.setRequestHeader('X-Blink-Config',
@@ -33,11 +34,6 @@ define(function (require) {
     });
 
     require(['bic/router']);
-  }
-
-  // delay the app for Cordova if present
-  whenBlinkGapReady.then(function () {
-    start();
   });
 
   window.BMP.BIC = app;
@@ -45,6 +41,8 @@ define(function (require) {
   window.BMP.BIC3 = app;
 
   window.BMP.BIC.version = '3.8.0';
+
+  window.BMP.console = require('bic/console');
 
   return app; // export BMP.BIC
 });

--- a/src/bic/api/native.js
+++ b/src/bic/api/native.js
@@ -5,7 +5,7 @@ define(function (require) {
   // foreign modules
 
   var $ = require('jquery');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // local modules
 

--- a/src/bic/api/native.js
+++ b/src/bic/api/native.js
@@ -5,7 +5,7 @@ define(function (require) {
   // foreign modules
 
   var $ = require('jquery');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // local modules
 

--- a/src/bic/api/web.js
+++ b/src/bic/api/web.js
@@ -4,7 +4,7 @@ define(function (require) {
   // foreign modules
 
   var $ = require('jquery');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
   var uuid = require('uuid');
 
   // this module

--- a/src/bic/api/web.js
+++ b/src/bic/api/web.js
@@ -4,7 +4,7 @@ define(function (require) {
   // foreign modules
 
   var $ = require('jquery');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
   var uuid = require('uuid');
 
   // this module

--- a/src/bic/backbone-fix.js
+++ b/src/bic/backbone-fix.js
@@ -4,7 +4,7 @@ define(function (require) {
   // foreign modules
 
   var Backbone = require('backbone');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // this module
 

--- a/src/bic/backbone-fix.js
+++ b/src/bic/backbone-fix.js
@@ -4,7 +4,7 @@ define(function (require) {
   // foreign modules
 
   var Backbone = require('backbone');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // this module
 

--- a/src/bic/collection.js
+++ b/src/bic/collection.js
@@ -5,7 +5,7 @@ define(function (require) {
 
   var _ = require('underscore');
   var Backbone = require('backbone');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // local modules
 

--- a/src/bic/collection.js
+++ b/src/bic/collection.js
@@ -5,7 +5,7 @@ define(function (require) {
 
   var _ = require('underscore');
   var Backbone = require('backbone');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // local modules
 

--- a/src/bic/collection/datasuitcases.js
+++ b/src/bic/collection/datasuitcases.js
@@ -3,7 +3,7 @@ define(function (require) {
 
   // foreign modules
 
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // local modules
 

--- a/src/bic/collection/datasuitcases.js
+++ b/src/bic/collection/datasuitcases.js
@@ -3,7 +3,7 @@ define(function (require) {
 
   // foreign modules
 
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // local modules
 

--- a/src/bic/collection/form-records.js
+++ b/src/bic/collection/form-records.js
@@ -4,7 +4,7 @@ define(function (require) {
   // foreign modules
 
   var _ = require('underscore');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
 
   // local modules

--- a/src/bic/collection/form-records.js
+++ b/src/bic/collection/form-records.js
@@ -4,7 +4,7 @@ define(function (require) {
   // foreign modules
 
   var _ = require('underscore');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
 
   // local modules

--- a/src/bic/collection/forms.js
+++ b/src/bic/collection/forms.js
@@ -5,7 +5,7 @@ define(function (require) {
 
   var _ = require('underscore');
   var Forms = require('BlinkForms');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // local modules
 

--- a/src/bic/collection/forms.js
+++ b/src/bic/collection/forms.js
@@ -5,7 +5,7 @@ define(function (require) {
 
   var _ = require('underscore');
   var Forms = require('BlinkForms');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // local modules
 

--- a/src/bic/console.js
+++ b/src/bic/console.js
@@ -1,0 +1,38 @@
+define(function () {
+  'use strict';
+
+  var mod = {};
+  var noop = function () { return false; };
+
+  // function domLog (msg) {
+  //   var p = document.createElement('p');
+  //   p.appendChild(document.createTextNode(msg));
+  //   return document.body.appendChild(p);
+  // }
+
+  [
+    'assert', 'debug', 'error', 'log', 'time', 'timeEnd', 'warn'
+  ].forEach(function (prop) {
+    if (window.console && typeof window.console[prop] === 'function') {
+      mod[prop] = function (a, b) {
+        // if (arguments.length >= 2) {
+        //   domLog(prop + ': ' + a + ' ' + b);
+        // } else {
+        //   domLog(prop + ': ' + a);
+        // }
+        try {
+          return window.console[prop].apply(window.console, arguments);
+        } catch (err) {
+          if (arguments.length >= 2) {
+            return window.console[prop](a, b);
+          }
+          return window.console[prop](a);
+        }
+      };
+    } else {
+      mod[prop] = noop;
+    }
+  });
+
+  return mod;
+});

--- a/src/bic/console.js
+++ b/src/bic/console.js
@@ -1,33 +1,45 @@
 define(function () {
   'use strict';
 
+  // foreign modules
+
+  var _ = require('underscore');
+
+  // this module
+
   var mod = {};
   var noop = function () { return false; };
 
-  // function domLog (msg) {
-  //   var p = document.createElement('p');
-  //   p.appendChild(document.createTextNode(msg));
-  //   return document.body.appendChild(p);
-  // }
+  function logToDOM () {
+    var args = _.toArray(arguments);
+    var li = document.createElement('li');
+    li.appendChild(document.createTextNode(args.join(' ')));
+    return mod.logElement.appendChild(li);
+  }
 
-  [
-    'assert', 'debug', 'error', 'log', 'time', 'timeEnd', 'warn'
-  ].forEach(function (prop) {
+  /** in order of decreasing noise / increasing importance */
+  mod.LOG_LEVELS = ['debug', 'info', 'log', 'warn', 'error'];
+
+  // mod.logLevel = 0; // 'debug'
+  mod.logLevel = 2; // 'log'
+
+  mod.logElement = null;
+
+  mod.LOG_LEVELS.forEach(function (prop, level) {
     if (window.console && typeof window.console[prop] === 'function') {
-      mod[prop] = function (a, b) {
-        // if (arguments.length >= 2) {
-        //   domLog(prop + ': ' + a + ' ' + b);
-        // } else {
-        //   domLog(prop + ': ' + a);
-        // }
+      mod[prop] = function () {
+        var args;
+        if (mod.logLevel > level) {
+          return false;
+        }
+        if (mod.logElement) {
+          args = _.toArray(arguments);
+          args.unshift(prop + ':');
+          logToDOM.apply(null, args);
+        }
         try {
           return window.console[prop].apply(window.console, arguments);
-        } catch (err) {
-          if (arguments.length >= 2) {
-            return window.console[prop](a, b);
-          }
-          return window.console[prop](a);
-        }
+        } catch (ignore) { return false; }
       };
     } else {
       mod[prop] = noop;

--- a/src/bic/data.js
+++ b/src/bic/data.js
@@ -5,7 +5,7 @@ define(function (require) {
 
   var _ = require('underscore');
   var Pouch = require('pouchdb');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // local modules
 

--- a/src/bic/data.js
+++ b/src/bic/data.js
@@ -5,7 +5,7 @@ define(function (require) {
 
   var _ = require('underscore');
   var Pouch = require('pouchdb');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // local modules
 

--- a/src/bic/debug-jquery.js
+++ b/src/bic/debug-jquery.js
@@ -1,0 +1,125 @@
+define(function (require) {
+'use strict';
+
+  // foreign modules
+
+  var $ = require('jquery');
+
+  // local modules
+
+  var c = require('bic/console');
+
+  // this module
+
+  var oldOnError = window.onerror;
+  // var support = {};
+
+  require('feature!es5');
+  require('jquerymobile');
+
+  // Object.keys($.support).forEach(function (prop) {
+  //   if (typeof $.support[prop] === 'boolean') {
+  //     support[prop] = $.support[prop];
+  //   }
+  // });
+  // c.debug('$.support: ' + JSON.stringify(support, null, 2));
+  // support = null;
+
+  function toString (value) {
+    if (Array.isArray(value)) {
+      return 'array[' + value.length + ']';
+    }
+    if (value === null || value === undefined || typeof value === 'boolean' || typeof value === 'number') {
+      return '' + value;
+    }
+    if (typeof value === 'string') {
+      if (value.length <= 20) {
+        return '"' + value + '"';
+      }
+      return '"' + value.substring(0, 20) + '..."[' + value.length + ']';
+    }
+    return typeof value;
+  }
+
+  function elToString (el) {
+    var output = el.tagName;
+    if (el.id) {
+      output += '#' + el.id;
+    }
+    return output;
+  }
+
+  function logEvent (event, prefix) {
+    var target;
+    prefix = prefix || '';
+    if (!event || !event.target || event.target === window) {
+      target = 'WINDOW';
+    } else {
+      target = elToString(event.target);
+    }
+    c.debug(prefix + 'event: ' + event.type + ' on ' + target);
+  }
+
+  function logFnDecorator (fn, prefix) {
+    var oldFn = fn.context[fn.name];
+    prefix = prefix || '';
+    fn.context[fn.name] = function (first) {
+      c.debug(prefix + fn.name + '(' + toString(first) + '): ...');
+      return oldFn.apply(this, arguments);
+    };
+  }
+
+  window.onerror = function (msg, url, line) {
+    c.error([msg, url, line].join(' '));
+    if (oldOnError) {
+      return oldOnError(msg, url, line);
+    }
+    return true;
+  };
+
+  [
+    'animationend', 'animationstart', 'pagehide', 'pageshow'
+  ].forEach(function (name) {
+    $(window).on(name, function (event) {
+      logEvent(event, '');
+    });
+  });
+
+  [
+    'hashchange', 'navigate', 'pagebeforechange', 'pagebeforecreate',
+    'pagebeforehide', 'pagebeforeload', 'pagebeforeshow', 'pagechange',
+    'pagechangefailed', 'pagecreate', 'pageinit', 'pageload', 'pageloadfailed',
+    'pageremove'
+  ].forEach(function (name) {
+    $(window).on(name, function (event) {
+      logEvent(event, '$.mobile: ');
+    });
+  });
+
+  [
+    { context: $.mobile.navigate.history, name: 'add' }
+  ].forEach(function (fn) {
+    logFnDecorator(fn, '$.mobile.navigate.history.');
+  });
+
+  [
+    { context: $.fn, name: 'animationComplete' }
+  ].forEach(function (fn) {
+    logFnDecorator(fn, '$.fn.');
+  });
+
+  [
+    { context: $.mobile, name: '_bindPageRemove' },
+    { context: $.mobile, name: '_handleHashChange' },
+    { context: $.mobile, name: '_maybeDegradeTransition' },
+    { context: $.mobile, name: '_registerInternalEvents' },
+    { context: $.mobile, name: 'changePage' },
+    { context: $.mobile, name: 'focusPage' },
+    { context: $.mobile, name: 'hidePageLoadingMsg' },
+    { context: $.mobile, name: 'loadPage' },
+    { context: $.mobile, name: 'resetActivePageHeight' }
+  ].forEach(function (fn) {
+    logFnDecorator(fn, '$.mobile.');
+  });
+
+});

--- a/src/bic/fix-animation.js
+++ b/src/bic/fix-animation.js
@@ -4,6 +4,7 @@ define(function (require) {
   // foreign modules
 
   var $ = require('jquery');
+  var $mobile = require('jquerymobile');
   var _ = require('underscore');
 
   // local modules
@@ -12,14 +13,17 @@ define(function (require) {
 
   // this module
 
+  var TRANSITIONS = Object.keys($mobile.transitionFallbacks);
+  TRANSITIONS.push('fade');
+
   function isJQMTransition (event) {
     var classes;
     if (!event || !event.target) {
       return false;
     }
     classes = event.target.className.split(' ');
-    return _.contains(classes, 'fade') &&
-      (_.contains(classes, 'in') || _.contains(classes, 'out'));
+    return (_.contains(classes, 'in') || _.contains(classes, 'out')) &&
+      !!_.intersection(classes, TRANSITIONS).length;
   }
 
   $(window).on('animationstart', function (event) {

--- a/src/bic/fix-animation.js
+++ b/src/bic/fix-animation.js
@@ -1,0 +1,39 @@
+define(function (require) {
+  'use strict';
+
+  // foreign modules
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+
+  // local modules
+
+  var c = require('bic/console');
+
+  // this module
+
+  function isJQMTransition (event) {
+    var classes;
+    if (!event || !event.target) {
+      return false;
+    }
+    classes = event.target.className.split(' ');
+    return _.contains(classes, 'fade') &&
+      (_.contains(classes, 'in') || _.contains(classes, 'out'));
+  }
+
+  $(window).on('animationstart', function (event) {
+    var timer;
+    if (isJQMTransition(event)) {
+      // okay, we need to set a 1s timer in case this doesn't finish
+      timer = setTimeout(function () {
+        c.warn('"animationend" event expected but not observed');
+        $(event.target).trigger('animationend');
+      }, 1e3);
+      $(event.target).one('animationend', function () {
+        clearTimeout(timer);
+      });
+    }
+  });
+
+});

--- a/src/bic/form-expressions.js
+++ b/src/bic/form-expressions.js
@@ -9,7 +9,7 @@ define(function (require) {
   // foreign modules
 
   var $ = require('jquery');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
   require('jquerymobile');
   require('BlinkForms');
 

--- a/src/bic/form-expressions.js
+++ b/src/bic/form-expressions.js
@@ -9,7 +9,7 @@ define(function (require) {
   // foreign modules
 
   var $ = require('jquery');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
   require('jquerymobile');
   require('BlinkForms');
 

--- a/src/bic/mediator.js
+++ b/src/bic/mediator.js
@@ -1,5 +1,11 @@
-define([], function () {
+define(function (require) {
   'use strict';
+
+  // local modules
+
+  var c = require('bic/console');
+
+  // this module
 
   var publish;
   var subscribe;
@@ -10,9 +16,7 @@ define([], function () {
   mediator.channels = {};
 
   log = function (type, channel, args) {
-    /*eslint-disable no-console*/
-    console.log(Date.now() + ': ' + type + ' ' + channel, args);
-    /*eslint-enable no-console*/
+    c.log(Date.now() + ': ' + type + ' ' + channel, args);
   };
 
   publish = function (channel) {

--- a/src/bic/model/application.js
+++ b/src/bic/model/application.js
@@ -244,12 +244,12 @@ define(function (require) {
         me.collections().then(function () {
           var timeout;
           if (me.interactions.length) {
-            c.log('app.whenPopulated(): done');
+            c.info('app.whenPopulated(): done');
             resolve();
           } else {
             me.interactions.once('add', function () {
               clearTimeout(timeout);
-              c.log('app.whenPopulated(): done');
+              c.info('app.whenPopulated(): done');
               resolve();
             });
             timeout = setTimeout(function () {

--- a/src/bic/model/application.js
+++ b/src/bic/model/application.js
@@ -14,7 +14,7 @@ define(function (require) {
   var _ = require('underscore');
   var Backbone = require('backbone');
   var domReady = require('domReady');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // local modules
 

--- a/src/bic/model/application.js
+++ b/src/bic/model/application.js
@@ -135,7 +135,7 @@ define(function (require) {
       var app = this;
 
       if (!(navigator.onLine || BMP.BlinkGap.isHere())) {
-        c.log('app.populate(): quit early');
+        c.debug('app.populate(): quit early');
         return Promise.resolve();
       }
 
@@ -209,7 +209,7 @@ define(function (require) {
             app.forms.whenUpdated();
             app.retrieveDataSuitcasesForInteractions();
             c.log('app.populate(): done');
-            c.log('app.populate(): interactions.length: ' + app.interactions.length);
+            c.debug('app.populate(): interactions.length: ' + app.interactions.length);
             if (!app.hasStorage()) {
               return Promise.resolve();
             }
@@ -234,7 +234,6 @@ define(function (require) {
         })
       )
       .then(function () {
-        c.log('app.retrieveDataSuitcasesForInteractions(): save()ing...');
         return app.datasuitcases.save();
       });
     },
@@ -287,7 +286,6 @@ define(function (require) {
     initialRender: function () {
       var app = this;
 
-      c.log('app.initialRender()...');
       $.mobile.defaultPageTransition = app.get('defaultTransition');
       $.mobile.changePage($.mobile.path.parseLocation().href, {
         changeHash: false,
@@ -295,7 +293,6 @@ define(function (require) {
         transition: 'fade'
       });
       $(document).one('pageshow', function () {
-        c.log('app.initialRender(): pageshow...');
         if (window.BootStatus && window.BootStatus.notifySuccess) {
           window.BootStatus.notifySuccess();
         }

--- a/src/bic/model/application.js
+++ b/src/bic/model/application.js
@@ -14,7 +14,7 @@ define(function (require) {
   var _ = require('underscore');
   var Backbone = require('backbone');
   var domReady = require('domReady');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // local modules
 

--- a/src/bic/model/application.js
+++ b/src/bic/model/application.js
@@ -13,7 +13,6 @@ define(function (require) {
   var $ = require('jquery');
   var _ = require('underscore');
   var Backbone = require('backbone');
-  var domReady = require('domReady');
   var Promise = require('bic/promise');
 
   // local modules
@@ -290,20 +289,17 @@ define(function (require) {
 
       c.log('app.initialRender()...');
       $.mobile.defaultPageTransition = app.get('defaultTransition');
-      domReady(function () {
-        c.log('app.initialRender(): domReady...');
-        $.mobile.changePage($.mobile.path.parseLocation().href, {
-          changeHash: false,
-          reloadPage: true,
-          transition: 'fade'
-        });
-        $(document).one('pageshow', function () {
-          c.log('app.initialRender(): pageshow...');
-          if (window.BootStatus && window.BootStatus.notifySuccess) {
-            window.BootStatus.notifySuccess();
-          }
-          $('#temp').remove();
-        });
+      $.mobile.changePage($.mobile.path.parseLocation().href, {
+        changeHash: false,
+        reloadPage: true,
+        transition: 'fade'
+      });
+      $(document).one('pageshow', function () {
+        c.log('app.initialRender(): pageshow...');
+        if (window.BootStatus && window.BootStatus.notifySuccess) {
+          window.BootStatus.notifySuccess();
+        }
+        $('#temp').remove();
       });
     },
 

--- a/src/bic/model/datasuitcase.js
+++ b/src/bic/model/datasuitcase.js
@@ -4,7 +4,7 @@ define(function (require) {
   // foreign modules
 
   var Backbone = require('backbone');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // local modules
 

--- a/src/bic/model/datasuitcase.js
+++ b/src/bic/model/datasuitcase.js
@@ -4,7 +4,7 @@ define(function (require) {
   // foreign modules
 
   var Backbone = require('backbone');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // local modules
 

--- a/src/bic/model/interaction.js
+++ b/src/bic/model/interaction.js
@@ -259,7 +259,7 @@ The argument change event.
             reject();
           }
         } else {
-          model.defaultView(app.interactions.models);
+          model.defaultView(app.interactions.models, app.siteVars);
           resolve(model);
         }
       });

--- a/src/bic/model/interaction.js
+++ b/src/bic/model/interaction.js
@@ -6,7 +6,7 @@ define(function (require) {
   var $ = require('jquery');
   var _ = require('underscore');
   var Backbone = require('backbone');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // local modules
 

--- a/src/bic/model/interaction.js
+++ b/src/bic/model/interaction.js
@@ -6,7 +6,7 @@ define(function (require) {
   var $ = require('jquery');
   var _ = require('underscore');
   var Backbone = require('backbone');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // local modules
 

--- a/src/bic/promise-blinkgap.js
+++ b/src/bic/promise-blinkgap.js
@@ -6,6 +6,10 @@ define(function () {
   var deadline = require('@jokeyrhyme/deadline');
   var Promise = require('bic/promise');
 
+  // local modules
+
+  var c = require('bic/console');
+
   // this module
 
   var realPromise; // not jQuery.Deferred, yuck!
@@ -22,9 +26,8 @@ define(function () {
 
     /** @type {Promise} always resolved, never rejected */
     return realPromise.then(null, function (err) {
-      if (window.console && window.console.error) {
-        window.console.error('BMP.BlinkGap.whenReady()', err);
-      }
+      c.error('BMP.BlinkGap.whenReady()');
+      c.error(err);
       return Promise.resolve();
     });
   }

--- a/src/bic/promise-blinkgap.js
+++ b/src/bic/promise-blinkgap.js
@@ -4,7 +4,7 @@ define(function () {
   // foreign modules
 
   var deadline = require('@jokeyrhyme/deadline');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // this module
 

--- a/src/bic/promise-blinkgap.js
+++ b/src/bic/promise-blinkgap.js
@@ -1,4 +1,4 @@
-define(function () {
+define(function (require) {
   'use strict';
 
   // foreign modules

--- a/src/bic/promise-blinkgap.js
+++ b/src/bic/promise-blinkgap.js
@@ -3,6 +3,7 @@ define(function () {
 
   // foreign modules
 
+  var deadline = require('@jokeyrhyme/deadline');
   var Promise = require('feature!promises');
 
   // this module
@@ -15,6 +16,9 @@ define(function () {
 
     // convert jQuery.Deferred to an ES6 Promise so we can safely chain it
     realPromise = Promise.resolve(window.BMP.BlinkGap.whenReady());
+
+    // wait a maximum of 5 seconds for this to be resolved
+    realPromise = deadline.promise(realPromise, 5e3);
 
     /** @type {Promise} always resolved, never rejected */
     return realPromise.then(null, function (err) {

--- a/src/bic/promise-blinkgap.js
+++ b/src/bic/promise-blinkgap.js
@@ -4,7 +4,7 @@ define(function () {
   // foreign modules
 
   var deadline = require('@jokeyrhyme/deadline');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // this module
 

--- a/src/bic/promise-dom-ready.js
+++ b/src/bic/promise-dom-ready.js
@@ -1,0 +1,22 @@
+define(function (require) {
+  'use strict';
+
+  // foreign modules
+
+  var domReady = require('domReady');
+  var Promise = require('bic/promise');
+
+  // local modules
+
+  var c = require('bic/console');
+
+  // this module
+
+  return new Promise(function (resolve) {
+    domReady(function () {
+      c.debug('event: domReady');
+      resolve();
+    });
+  });
+
+});

--- a/src/bic/promise-indexeddb.js
+++ b/src/bic/promise-indexeddb.js
@@ -4,7 +4,7 @@ define(function (require) {
   // foreign modules
 
   var isIndexedDBReliable = require('is-indexeddb-reliable');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // local modules
 

--- a/src/bic/promise-indexeddb.js
+++ b/src/bic/promise-indexeddb.js
@@ -4,7 +4,7 @@ define(function (require) {
   // foreign modules
 
   var isIndexedDBReliable = require('is-indexeddb-reliable');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // local modules
 

--- a/src/bic/promise-indexeddb.js
+++ b/src/bic/promise-indexeddb.js
@@ -8,28 +8,27 @@ define(function (require) {
 
   // local modules
 
+  var c = require('bic/console');
+  var deadline = require('@jokeyrhyme/deadline');
   var whenBlinkGapReady = require('bic/promise-blinkgap');
 
   // this module
 
-  return whenBlinkGapReady.then(function () {
+  function isIt () {
     return new Promise(function (resolve) {
-      var timeout = false;
-      var timer = setTimeout(function () {
-        // timer never necessary for actual usage
-        // but timer _is_ mysteriously necessary for running the tests in Safari
-        if (window.console && window.console.warn) {
-          window.console.warn('timeout: IndexedDB tests too slow');
-        }
-        timeout = true;
-        resolve(false);
-      }, 1500); // pick a time under 2sec, which is the default test timeout
       isIndexedDBReliable.quick(function (result) {
-        if (!timeout) {
-          clearTimeout(timer);
-          resolve(result);
-        }
+        resolve(result);
       });
     });
+  }
+
+  return whenBlinkGapReady.then(function () {
+    // pick a time under 2sec, which is the default test timeout
+    return deadline.promise(isIt(), 1500).then(null, function () {
+      c.warn('timeout: IndexedDB tests too slow');
+      return Promise.resolve();
+    });
+    // timer should not be necessary for actual usage
+    // but timer _is_ mysteriously necessary for running the tests in Safari
   });
 });

--- a/src/bic/promise-pick-storage.js
+++ b/src/bic/promise-pick-storage.js
@@ -4,7 +4,7 @@ define(function (require) {
   // foreign modules
 
   var Pouch = require('pouchdb');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // local modules
 

--- a/src/bic/promise-pick-storage.js
+++ b/src/bic/promise-pick-storage.js
@@ -8,24 +8,23 @@ define(function (require) {
 
   // local modules
 
+  var c = require('bic/console');
   var whenIndexedDBReliable = require('bic/promise-indexeddb');
 
   // this module
 
-  var msg = 'no reliable persistent storage detected';
-
   return whenIndexedDBReliable.then(function (idb) {
     if (window.BMP.BIC.isBlinkGap === true) {
       if (Pouch.adapters.websql) {
+        c.info('persistent storage: websql');
         return Promise.resolve('websql');
       }
     }
     if (idb && Pouch.adapters.idb) {
+      c.info('persistent storage: idb');
       return Promise.resolve('idb');
     }
-    if (window.console && window.console.warn) {
-      window.console.warn(msg);
-    }
+    c.warn('no reliable persistent storage detected');
     return Promise.resolve(null);
   });
 });

--- a/src/bic/promise-pick-storage.js
+++ b/src/bic/promise-pick-storage.js
@@ -4,7 +4,7 @@ define(function (require) {
   // foreign modules
 
   var Pouch = require('pouchdb');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // local modules
 

--- a/src/bic/promise.js
+++ b/src/bic/promise.js
@@ -1,0 +1,6 @@
+define(['feature!promises'], function (Promise) {
+  // poly-fill Promise if missing (needed for Forms, etc)
+  window.Promise = window.Promise || Promise;
+
+  return Promise;
+});

--- a/src/bic/promise.js
+++ b/src/bic/promise.js
@@ -1,4 +1,6 @@
 define(['feature!promises'], function (Promise) {
+  'use strict';
+
   // poly-fill Promise if missing (needed for Forms, etc)
   window.Promise = window.Promise || Promise;
 

--- a/src/bic/router.js
+++ b/src/bic/router.js
@@ -148,6 +148,9 @@ define(function (require) {
               c.log('router.routeRequest(): modelView: after render...');
               this.$el.attr('data-url', data.dataUrl ); // .replace(/['"]/g, convertIllegalUrlChars));
               this.$el.attr('data-external-page', true);
+              this.$el.one('pagecreate', function () {
+                c.log('router.routeRequest(): modelView: after pagecreate...');
+              });
               this.$el.one('pagecreate', $.mobile._bindPageRemove);
               data.deferred.resolve(data.absUrl, data.options, this.$el);
             }).render(data);

--- a/src/bic/router.js
+++ b/src/bic/router.js
@@ -15,6 +15,7 @@ define(function (require) {
   var c = require('bic/console');
   var InteractionView = require('bic/view/interaction');
   var uiTools = require('bic/lib/ui-tools');
+  var whenDOMReady = require('bic/promise-dom-ready');
 
   // this module
 
@@ -100,6 +101,7 @@ define(function (require) {
           c.error(err);
           return;
         })
+        .then(whenDOMReady)
         .then(function () {
           return app.initialRender();
         })

--- a/src/bic/router.js
+++ b/src/bic/router.js
@@ -7,7 +7,7 @@ define(function (require) {
   var _ = require('underscore');
   var Backbone = require('backbone');
   var Modernizr = require('modernizr');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // local modules
 

--- a/src/bic/router.js
+++ b/src/bic/router.js
@@ -7,7 +7,7 @@ define(function (require) {
   var _ = require('underscore');
   var Backbone = require('backbone');
   var Modernizr = require('modernizr');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // local modules
 

--- a/src/bic/view/form/action.js
+++ b/src/bic/view/form/action.js
@@ -9,6 +9,7 @@ define(function (require) {
 
   // local modules
 
+  var c = require('bic/console');
   var app = require('bic/model/application');
   var FormControls = require('bic/view/form/controls');
   var FormErrorSummary = require('bic/view/form/error-summary-list');
@@ -109,7 +110,7 @@ define(function (require) {
         .then(null, function (err) {
           view.$el.append('<p>Error: unable to display this form. Try again later.</p>');
           view.trigger('render');
-          window.console.log(err);
+          c.log(err);
         });
 
       return view;

--- a/src/bic/view/form/action.js
+++ b/src/bic/view/form/action.js
@@ -110,7 +110,7 @@ define(function (require) {
         .then(null, function (err) {
           view.$el.append('<p>Error: unable to display this form. Try again later.</p>');
           view.trigger('render');
-          c.log(err);
+          c.error(err);
         });
 
       return view;

--- a/src/bic/view/form/controls.js
+++ b/src/bic/view/form/controls.js
@@ -7,7 +7,7 @@ define(function (require) {
   var Backbone = require('backbone');
   var Forms = require('BlinkForms');
   var Mustache = require('mustache');
-  var Promise = require('feature!promises');
+  var Promise = require('bic/promise');;
 
   // local modules
 

--- a/src/bic/view/form/controls.js
+++ b/src/bic/view/form/controls.js
@@ -7,7 +7,7 @@ define(function (require) {
   var Backbone = require('backbone');
   var Forms = require('BlinkForms');
   var Mustache = require('mustache');
-  var Promise = require('bic/promise');;
+  var Promise = require('bic/promise');
 
   // local modules
 

--- a/src/bic/view/interaction.js
+++ b/src/bic/view/interaction.js
@@ -170,8 +170,6 @@ define(function (require) {
           inheritedAttributes = this.model.inherit({}),
           view = this;
 
-        c.log('InteractionView#render()...');
-
         // Non-type specific
         if (_.has(inheritedAttributes, 'themeSwatch')) {
           this.$el.attr('data-theme', inheritedAttributes.themeSwatch);
@@ -244,7 +242,6 @@ define(function (require) {
 
         } else if (this.model.id.toLowerCase() === window.BMP.BIC.siteVars.answerSpace.toLowerCase()) {
           // Home Screen
-          c.log('InteractionView#render(): home screen...');
           view.$el.html(Mustache.render(Template, {
             header: inheritedAttributes.header,
             footer: inheritedAttributes.footer,
@@ -256,7 +253,6 @@ define(function (require) {
           view.trigger('render');
         } else if (!this.model.has('type')) {
           // Category
-          c.log('InteractionView#render(): category...');
           view.$el.html(Mustache.render(Template, {
             header: inheritedAttributes.header,
             footer: inheritedAttributes.footer,

--- a/src/bic/view/interaction.js
+++ b/src/bic/view/interaction.js
@@ -13,6 +13,7 @@ define(function (require) {
 
     // local modules
 
+    var c = require('bic/console');
     var Template = require('text!bic/template/interaction.mustache');
     var inputPromptTemplate = require('text!bic/template/inputPrompt.mustache');
     var categoryTemplate = require('text!bic/template/category-list.mustache');
@@ -169,6 +170,8 @@ define(function (require) {
           inheritedAttributes = this.model.inherit({}),
           view = this;
 
+        c.log('InteractionView#render()...');
+
         // Non-type specific
         if (_.has(inheritedAttributes, 'themeSwatch')) {
           this.$el.attr('data-theme', inheritedAttributes.themeSwatch);
@@ -241,6 +244,7 @@ define(function (require) {
 
         } else if (this.model.id.toLowerCase() === window.BMP.BIC.siteVars.answerSpace.toLowerCase()) {
           // Home Screen
+          c.log('InteractionView#render(): home screen...');
           view.$el.html(Mustache.render(Template, {
             header: inheritedAttributes.header,
             footer: inheritedAttributes.footer,
@@ -252,6 +256,7 @@ define(function (require) {
           view.trigger('render');
         } else if (!this.model.has('type')) {
           // Category
+          c.log('InteractionView#render(): category...');
           view.$el.html(Mustache.render(Template, {
             header: inheritedAttributes.header,
             footer: inheritedAttributes.footer,

--- a/src/bic/view/interaction.js
+++ b/src/bic/view/interaction.js
@@ -9,7 +9,7 @@ define(function (require) {
     var Backbone = require('backbone');
     var geolocation = require('@blinkmobile/geolocation');
     var Mustache = require('mustache');
-    var Promise = require('bic/promise');;
+    var Promise = require('bic/promise');
 
     // local modules
 

--- a/src/bic/view/interaction.js
+++ b/src/bic/view/interaction.js
@@ -13,7 +13,6 @@ define(function (require) {
 
     // local modules
 
-    var c = require('bic/console');
     var Template = require('text!bic/template/interaction.mustache');
     var inputPromptTemplate = require('text!bic/template/inputPrompt.mustache');
     var categoryTemplate = require('text!bic/template/category-list.mustache');

--- a/src/bic/view/interaction.js
+++ b/src/bic/view/interaction.js
@@ -9,7 +9,7 @@ define(function (require) {
     var Backbone = require('backbone');
     var geolocation = require('@blinkmobile/geolocation');
     var Mustache = require('mustache');
-    var Promise = require('feature!promises');
+    var Promise = require('bic/promise');;
 
     // local modules
 

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -8,6 +8,7 @@ require.config({
     'is-indexeddb-reliable': 'node_modules/is-indexeddb-reliable/dist/index',
     feature: 'node_modules/amd-feature/feature',
     '@blinkmobile/geolocation': 'node_modules/@blinkmobile/geolocation/geolocation',
+    '@jokeyrhyme/deadline': 'node_modules/@jokeyrhyme/deadline/dist/index',
     Squire: 'node_modules/squirejs/src/Squire',
     pollUntil: 'node_modules/poll-until/poll-until',
     mustache: 'node_modules/mustache/mustache',

--- a/tests/support/server.js
+++ b/tests/support/server.js
@@ -14,6 +14,14 @@ var Mustache = require('mustache');
 
 // this module
 
+/*eslint-disable no-process-env*/ // not production code here, relax!
+var BMP_HOST = process.env.BMP_HOST || 'blinkm.co';
+/*eslint-disable no-process-env*/
+
+var STATIC_PATHS = [
+  '_c_', '_BICv3_', '_R_', '_W_', '_api', 'active_pages', 'admin', 'admintools', 'api_access', 'gfx', 'icons', 'livezone', 'tools', 'text3y'
+];
+
 var pkg = require(path.join(__dirname, '..', '..', 'package.json'));
 
 var server = new Hapi.Server();
@@ -27,6 +35,14 @@ server.connection({
   tls: {
     key: fs.readFileSync('tests/support/key.pem'),
     cert: fs.readFileSync('tests/support/cert.pem')
+  }
+});
+
+server.route({
+  path: '/favicon.ico',
+  method: 'GET',
+  handler: {
+    file: 'favicon.ico'
   }
 });
 
@@ -50,59 +66,37 @@ server.route({
     contents = contents.replace('/_c_/blink/bic/{{id}}/bic.min.js\n', '');
     contents = contents.replace('/_c_/blink/bic/{{id}}/bic.js', '/bic.js');
     contents = contents.replace(/^\/_c_\//mg, '//d1c6dfkb81l78v.cloudfront.net/');
-    contents += '\nCACHE:\n/_R_/common/3/xhr/GetConfig.php?_asn=integration\n';
+    contents += '\nCACHE:\n/_R_/common/3/xhr/GetConfig.php?_asn=' + request.query.answerSpace + '\n';
     reply(contents).header('Content-Type', 'text/cache-manifest');
   }
+});
+
+STATIC_PATHS.forEach(function (s) {
+  server.route({
+    path: '/' + s + '/{param*}',
+    method: ['GET', 'POST'],
+    handler: {
+      proxy: {
+        host: BMP_HOST,
+        port: 80,
+        protocol: 'http',
+        passThrough: true
+      }
+    }
+  });
 });
 
 server.route({
   path: '/{param*}',
   method: 'GET',
-  handler: {
-    directory: {
-      path: './',
-      listing: true
-    }
-  }
-});
-
-server.route({
-  path: '/integration/{param*}',
-  method: 'GET',
   handler: function (request, reply) {
     var templatePath = path.join(__dirname, '..', '..', 'src', 'buildFiles', 'files', 'index.mustache');
     var contents = fs.readFileSync(templatePath, { encoding: 'utf8' });
-    require('./template-data')(request, function (err, data) {
+    require('./template-data')(BMP_HOST, request, function (err, data) {
       if (err) { throw err; }
       contents = Mustache.render(contents, data);
       reply(contents).header('Content-Type', 'text/html');
     });
-  }
-});
-
-server.route({
-  path: '/_R_/{param*}',
-  method: ['GET', 'POST'],
-  handler: {
-    proxy: {
-      host: 'blinkm.co',
-      port: 80,
-      protocol: 'http',
-      passThrough: true
-    }
-  }
-});
-
-server.route({
-  path: '/_c_/{param*}',
-  method: ['GET', 'POST'],
-  handler: {
-    proxy: {
-      host: 'blinkm.co',
-      port: 80,
-      protocol: 'http',
-      passThrough: true
-    }
   }
 });
 

--- a/tests/support/template-data.js
+++ b/tests/support/template-data.js
@@ -30,7 +30,7 @@ module.exports = function (BMP_HOST, req, callback) {
   var searchParts = search.split('/');
   var answerSpace = searchParts[0];
 
-  request('http://' + BMP_HOST +'/_R_/common/3/xhr/GetConfig.php?_asn=' + answerSpace, {
+  request('http://' + BMP_HOST + '/_R_/common/3/xhr/GetConfig.php?_asn=' + answerSpace, {
     json: true
   }, function (err, res, body) {
     var spaces;

--- a/tests/support/template-data.js
+++ b/tests/support/template-data.js
@@ -24,13 +24,13 @@ var bicVersion = (function () {
   return JSON.parse(contents[1].trim());
 }());
 
-module.exports = function (req, callback) {
+module.exports = function (BMP_HOST, req, callback) {
 
   var search = req.path.replace(/^\//, '');
   var searchParts = search.split('/');
   var answerSpace = searchParts[0];
 
-  request('http://blinkm.co/_R_/common/3/xhr/GetConfig.php?_asn=' + answerSpace, {
+  request('http://' + BMP_HOST +'/_R_/common/3/xhr/GetConfig.php?_asn=' + answerSpace, {
     json: true
   }, function (err, res, body) {
     var spaces;
@@ -63,7 +63,7 @@ module.exports = function (req, callback) {
         }, ''),
         styleSheet: '',
         appCache: '',
-        appCachePermalink: '/appcache.manifest'
+        appCachePermalink: '/appcache.manifest?answerSpace=' + answerSpace
       },
 
       BIC: bicVersion


### PR DESCRIPTION
Primarily:
- upon "animationstart" event, add a watchdog that will emit "animationend" event in cases where the browser engine fails to emit it (within 1 second, only for jQM "fade" animation for now)
- fixed left-over issue after BIC-165

Additionally:
- make development server more flexible and convenient
- improve Promise poly-fill timing to be deterministically earlier
- add "bic/console" module and use it to simplify usage of `window.console`
- add "bic/promise-dom-ready" to tidy up dependency on Require.js domReady
- add logging messages in places to help with debugging