### PR TITLE
update to Backbone 1.2.1 and Underscore 1.8.3

### DIFF
--- a/src/buildFiles/templates/appcache.mustache
+++ b/src/buildFiles/templates/appcache.mustache
@@ -4,7 +4,7 @@ CACHE:
 /_c_/blink/require/6/require.min.js
 /_c_/blink/bic/{{id}}/bic.min.js
 /_c_/blink/bic/{{id}}/bic.js
-/_c_/backbonejs/1.1.2/backbone-min.js
+/_c_/backbonejs/1.2.1/backbone-min.js
 /_c_/blink/blobs/1377493706402/bmp-blobs.min.js
 /_c_/blink/forms/3/<% forms %>/forms3jqm.min.js
 /_c_/jquery.mobile/1.3.2/jquery.mobile-1.3.2.min.css
@@ -13,7 +13,7 @@ CACHE:
 /_c_/jquery.mobile/1.3.0/jqm.structure.min.css
 /_c_/jquery/1.11.3/jquery-1.11.3.min.js
 /_c_/jquery.mobile/1.3.2/jquery.mobile-1.3.2.min.js
-/_c_/lodash/2.4.1/lodash.underscore.min.js
+/_c_/underscorejs/1.8.3/underscore-min.js
 /_c_/mustache/0.7.3/mustache.min.js
 /_c_/moment/2.6.0/moment.min.js
 /_c_/moment/2.6.0/moment-with-langs.min.js

--- a/src/frag/00-config.js
+++ b/src/frag/00-config.js
@@ -53,10 +53,10 @@
     jquerymobile: getPaths('jquery.mobile/1.3.2/jquery.mobile-1.3.2.min'),
     jquery: getPaths('jquery/1.11.3/jquery-1.11.3.min'),
     bluebird: getPaths('bluebird/1.2.4/bluebird.min'),
-    backbone: getPaths('backbonejs/1.1.2/backbone-min'),
+    backbone: getPaths('backbonejs/1.2.1/backbone-min'),
     modernizr: getPaths('modernizr/2.7.1/modernizr.custom.26204.min'),
     mustache: getPaths('mustache/0.7.3/mustache.min'),
-    underscore: getPaths('lodash/2.4.1/lodash.underscore.min'),
+    underscore: getPaths('underscorejs/1.8.3/underscore-min'),
     'es5-shim': getPaths('es5-shim/2.3.0/es5-shim.min'),
     pouchdb: getPaths('pouchdb/3.2.1/pouchdb-3.2.1.min')
   };


### PR DESCRIPTION
I did try updating to jQuery 2.1.4, but it seems to break the widget factory in jQueryMobile 1.3.x. :S

All tests are passing with the Backbone and Underscore updates.