### PR TITLE
BIC-194 # interacting with some form elements (choice, camera, etc) can reload BIC

### DIFF
--- a/src/bic/router.js
+++ b/src/bic/router.js
@@ -45,15 +45,12 @@ define(function (require) {
       if (Modernizr.localstorage) {
         if (window.BMP.isBlinkGap) {
           $document.on('pause', this.suspendApplication);
-          $document.on('resume', this.resumeApplication);
         }
 
         if (document.hidden !== undefined) {
           $document.on('visibilitychange', function () {
             if (document.hidden) {
               app.router.suspendApplication();
-            } else {
-              app.router.resumeApplication();
             }
           });
         }

--- a/tests/support/server.js
+++ b/tests/support/server.js
@@ -112,7 +112,10 @@ server.route({
     require('./template-data')(BMP_HOST, request, function (err, data) {
       if (err) { throw err; }
       contents = Mustache.render(contents, data);
-      reply(contents).header('Content-Type', 'text/html');
+      reply(contents).header('Content-Type', 'text/html')
+        .header('X-BMP-Gap-Target', 'bmp-blinkgap-js')
+        .header("X-BMP-Version", "3.xx.x");
+
     });
   }
 });

--- a/tests/support/template-data.js
+++ b/tests/support/template-data.js
@@ -43,7 +43,9 @@ module.exports = function (BMP_HOST, req, callback) {
 
     callback(null, {
       _SERVER: request.headers,
-
+      _SESSION: {
+        "HTTP_USER_AGENT": req.headers["user-agent"]
+      },
       answerSpace: {
         id: answerSpaceId,
         name: answerSpace,


### PR DESCRIPTION
- router.js : removed calls to resumeApplication

- Server.js: use appropriate headers as BMP does, so cordova can attach things, if it needs to
- template-data.js: assign same user_agent as device

ux reviewed by Ray and Rachel