### PR TITLE
BIC-192 # lazy-load Forms library _after_ BIC is initialised

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,12 +10,6 @@
     /* Blink */
     "BMP": true,
     "BlinkForms": true,
-    /* Testing */
-    "mocha": true,
-    "sinon": true,
-    "should": true,
-    "expect": true,
-    "chai": true
   },
   "rules": {
     /* Possible Errors */

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,7 +45,7 @@ module.exports = function (grunt) {
     watch: {
       src: {
         files: ['src/**/**', 'tests/**/**'],
-        tasks: ['build', 'eslint', 'karma']
+        tasks: ['build', 'eslint', 'karma:phantom']
       }
     },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,6 +85,7 @@ module.exports = function (grunt) {
             '@blinkmobile/geolocation': '../node_modules/@blinkmobile/geolocation/geolocation',
             'is-indexeddb-reliable': '../node_modules/is-indexeddb-reliable/dist/index',
             '@jokeyrhyme/deadline': '../node_modules/@jokeyrhyme/deadline/dist/index',
+            '@jokeyrhyme/promised-requirejs': '../node_modules/@jokeyrhyme/promised-requirejs/dist/index',
             text: '../node_modules/text/text',
             domReady: '../node_modules/domReady/domReady',
             uuid: '../node_modules/node-uuid/uuid',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,6 +18,7 @@ module.exports = function (config) {
       { pattern: 'node_modules/is-indexeddb-reliable/dist/index.js', included: false },
       { pattern: 'node_modules/amd-feature/feature.js', included: false },
       { pattern: 'node_modules/@jokeyrhyme/deadline/dist/index.js', included: false },
+      { pattern: 'node_modules/@jokeyrhyme/promised-requirejs/dist/index.js', included: false },
       { pattern: 'node_modules/@blinkmobile/geolocation/geolocation.js', included: false },
       { pattern: 'node_modules/squirejs/src/Squire.js', included: false },
       { pattern: 'node_modules/poll-until/poll-until.js', included: false },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@blinkmobile/geolocation": "1.0.0",
     "@jokeyrhyme/deadline": "1.1.0",
+    "@jokeyrhyme/promised-requirejs": "^1.0.0",
     "amd-feature": "jensarps/AMD-feature#295cb395fe",
     "blinkgap-utils": "blinkmobile/blinkgap-utils#500774457d",
     "domReady": "requirejs/domReady#449478e133",

--- a/src/bic.js
+++ b/src/bic.js
@@ -11,8 +11,6 @@ define(function (require) {
   require('BMP.Blobs');
   require('jquerymobile');
 
-  window.BMP.Forms = require('BlinkForms');
-
   // local modules
 
   var app = require('bic/model/application');

--- a/src/bic/collection/forms.js
+++ b/src/bic/collection/forms.js
@@ -4,7 +4,6 @@ define(function (require) {
   // foreign modules
 
   var _ = require('underscore');
-  var Forms = require('BlinkForms');
   var Promise = require('bic/promise');
 
   // local modules
@@ -19,43 +18,6 @@ define(function (require) {
 
   var FormCollection = Collection.extend({
     model: Form,
-
-    initialize: function () {
-      if (!Forms) {
-        Forms = {};
-      }
-
-      // BlinkForms expects this function to be defined by whatever is using it.
-      // otherwise, subforms will fall over.
-      Forms.getDefinition = function (name, action) {
-        var app = window.BMP.BIC;
-        var formDefinition;
-
-        return app.forms.whenUpdated()
-        .then(function () {
-          return new Promise(function (resolve, reject) {
-            var def = app.forms.get(name);
-            if (!def) {
-              return reject(new Error('unable to locate "' + name + '" definition'));
-            }
-
-            try {
-              formDefinition = Forms.flattenDefinition(def.attributes, action);
-              // BlinkForms.flattenDefinition returns a non backbone object
-              // so lets make sure that the leave interactions defined exist on it, so
-              // BlinkForms will use them when creating the form model.
-              if (def.get('onFormLeaveInteraction')) {
-                formDefinition.onFormLeaveInteraction = def.get('onFormLeaveInteraction');
-              }
-              resolve(formDefinition);
-            } catch (err) {
-              reject(err);
-            }
-          });
-        });
-      };
-
-    },
 
     datastore: function () {
       return Collection.prototype.datastore.call(this, NAME);

--- a/src/bic/form-expressions.js
+++ b/src/bic/form-expressions.js
@@ -11,7 +11,6 @@ define(function (require) {
   var $ = require('jquery');
   var Promise = require('bic/promise');
   require('jquerymobile');
-  require('BlinkForms');
 
   // local modules
 

--- a/src/bic/model/application.js
+++ b/src/bic/model/application.js
@@ -28,6 +28,7 @@ define(function (require) {
   var facade = require('bic/facade');
   var API = require('bic/api');
   var metaStore = require('bic/store-meta');
+  var loadForms = require('bic/promise-forms');
 
   // this module
 
@@ -206,6 +207,7 @@ define(function (require) {
        )
         .then(
           function () {
+            loadForms();
             app.forms.whenUpdated();
             app.retrieveDataSuitcasesForInteractions();
             c.log('app.populate(): done');

--- a/src/bic/model/interaction.js
+++ b/src/bic/model/interaction.js
@@ -64,7 +64,8 @@ A model of an interaction
       content: null,
       contentTime: null,
       footer: null,
-      name: null
+      name: null,
+      currentForm: null // equivalent to Forms.current
     },
 
     inherit: function (config) {

--- a/src/bic/model/pending.js
+++ b/src/bic/model/pending.js
@@ -4,7 +4,6 @@ define(function (require) {
   // foreign modules
 
   var Backbone = require('backbone');
-  var Forms = require('BlinkForms');
 
   // local modules
   var MODEL_STATUS = require('bic/enum-model-status');
@@ -94,7 +93,7 @@ define(function (require) {
      */
     setErrors: function (errors) {
       if (errors.errors) {
-        errors.errors = Forms.errorHelpers.fromBMP(errors.errors);
+        errors.errors = window.BMP.Forms.errorHelpers.fromBMP(errors.errors);
       }
       this.set({
         status: MODEL_STATUS.FAILED_VALIDATION,

--- a/src/bic/promise-forms.js
+++ b/src/bic/promise-forms.js
@@ -1,0 +1,77 @@
+define(function (require) {
+  'use strict';
+
+  // foreign modules
+
+  var promisedRequire = require('@jokeyrhyme/promised-requirejs');
+
+  // local modules
+
+  var c = require('bic/console');
+
+  // this module
+
+  var Forms;
+
+  require('bic/promise'); // ensure `global.Promise` exists before starting
+
+  function getDefinition (name, action) {
+    var app = window.BMP.BIC;
+    var formDefinition;
+
+    return app.forms.whenUpdated()
+    .then(function () {
+      return new Promise(function (resolve, reject) {
+        var def = app.forms.get(name);
+        var err;
+        if (!def) {
+          c.error('BMP.Forms.getDefinition():');
+          err = new Error('unable to locate "' + name + '" definition');
+          c.error(err);
+          return reject(err);
+        }
+
+        try {
+          formDefinition = Forms.flattenDefinition(def.attributes, action);
+          // BlinkForms.flattenDefinition returns a non backbone object
+          // so lets make sure that the leave interactions defined exist on it, so
+          // BlinkForms will use them when creating the form model.
+          if (def.get('onFormLeaveInteraction')) {
+            formDefinition.onFormLeaveInteraction = def.get('onFormLeaveInteraction');
+          }
+          resolve(formDefinition);
+        } catch (err) {
+          c.error('BMP.Forms.getDefinition():');
+          c.error(err);
+          reject(err);
+        }
+      });
+    });
+  }
+
+  return function () {
+    return promisedRequire('BlinkForms')
+    .then(function (mod) {
+      Forms = mod;
+
+      // export to global, expected by Expressions
+      window.BMP.Forms = window.BMP.Forms || mod;
+
+      // BlinkForms expects this function to be defined by whatever is using it.
+      // otherwise, subforms will fall over.
+      Forms.getDefinition = Forms.getDefinition || getDefinition;
+
+      // we need to explicitly load "forms/jqm"
+      // otherwise sometimes the final Promise is resolved before we are ready
+      return promisedRequire('forms/jqm');
+    })
+    .then(function () {
+      return promisedRequire('bic/form-expressions');
+    })
+    .then(function () {
+      // consumers of this module expect it to resolve with Forms
+      return Promise.resolve(Forms);
+    });
+  };
+
+});

--- a/src/bic/router.js
+++ b/src/bic/router.js
@@ -14,6 +14,7 @@ define(function (require) {
   var app = require('bic/model/application');
   var c = require('bic/console');
   var InteractionView = require('bic/view/interaction');
+  var FormInteractionView = require('bic/view/interaction/form');
   var uiTools = require('bic/lib/ui-tools');
   var whenDOMReady = require('bic/promise-dom-ready');
 
@@ -140,7 +141,8 @@ define(function (require) {
           return model.prepareForView(data);
         })
         .then(function (model) {
-          return new InteractionView({
+          var View = model.get('type') === 'form' ? FormInteractionView : InteractionView;
+          return new View({
             tagName: 'div',
             model: model
           });

--- a/src/bic/router.js
+++ b/src/bic/router.js
@@ -137,23 +137,28 @@ define(function (require) {
           model.setArgsFromQueryString(path.search);
           app.currentInteraction = model;
 
-          model.prepareForView(data).then(function (innerModel) {
-            new InteractionView({
-              tagName: 'div',
-              model: innerModel
-            }).once('render', function () {
-              this.$el.attr('data-url', data.dataUrl); // .replace(/['"]/g, convertIllegalUrlChars));
-              this.$el.attr('data-external-page', true);
-              this.$el.one('pagecreate', $.mobile._bindPageRemove);
-
-              // http://api.jquerymobile.com/1.3/pagebeforeload/
-              // data.deferred.resolve|reject is expected after data.preventDefault()
-              data.deferred.resolve(data.absUrl, data.options, this.$el);
-            }).render(data);
+          return model.prepareForView(data);
+        })
+        .then(function (model) {
+          return new InteractionView({
+            tagName: 'div',
+            model: model
           });
         })
+        .then(function (view) {
+          view.once('render', function () {
+            this.$el.attr('data-url', data.dataUrl); // .replace(/['"]/g, convertIllegalUrlChars));
+            this.$el.attr('data-external-page', true);
+            this.$el.one('pagecreate', $.mobile._bindPageRemove);
+
+            // http://api.jquerymobile.com/1.3/pagebeforeload/
+            // data.deferred.resolve|reject is expected after data.preventDefault()
+            data.deferred.resolve(data.absUrl, data.options, this.$el);
+          });
+          view.render(data);
+        })
         // catch the error thrown when a model cant be found
-        .then(undefined, function (err) {
+        .catch(function (err) {
           c.error('router.routeRequest(): error...');
           c.error(err);
 

--- a/src/bic/view/form.js
+++ b/src/bic/view/form.js
@@ -45,6 +45,13 @@ define(function (require) {
       view.subView.render();
 
       return view;
+    },
+
+    remove: function () {
+      if (this.subView) {
+        this.subView.remove();
+      }
+      Backbone.View.prototype.remove.apply(this, arguments);
     }
   }, {
     prepareSubView: function () {

--- a/src/bic/view/form/action.js
+++ b/src/bic/view/form/action.js
@@ -78,6 +78,7 @@ define(function (require) {
           var pendingModel;
 
           Forms.initialize(definition, view.model.get('blinkFormAction'));
+          view.model.set('currentForm', Forms.current);
           view.$el.append(Forms.current.$form);
           view.$el.append(view.$errorSummaryContainer);
           view.renderControls();
@@ -117,6 +118,9 @@ define(function (require) {
     },
 
     remove: function () {
+      if (this.model && this.model.get('currentForm')) {
+        this.model.set('currentForm', null);
+      }
       if (this.subView) {
         this.subView.remove();
       }

--- a/src/bic/view/form/action.js
+++ b/src/bic/view/form/action.js
@@ -114,7 +114,15 @@ define(function (require) {
         });
 
       return view;
+    },
+
+    remove: function () {
+      if (this.subView) {
+        this.subView.remove();
+      }
+      Backbone.View.prototype.remove.apply(this, arguments);
     }
+
   }, {
     prepareSubView: function () {
       var SubView = FormControls;

--- a/src/bic/view/form/action.js
+++ b/src/bic/view/form/action.js
@@ -4,7 +4,6 @@ define(function (require) {
   // foreign modules
 
   var Backbone = require('backbone');
-  var Forms = require('BlinkForms');
   var $ = require('jquery');
 
   // local modules
@@ -13,6 +12,7 @@ define(function (require) {
   var app = require('bic/model/application');
   var FormControls = require('bic/view/form/controls');
   var FormErrorSummary = require('bic/view/form/error-summary-list');
+  var loadForms = require('bic/promise-forms');
 
   // this module
 
@@ -33,10 +33,11 @@ define(function (require) {
      */
     renderErrorSummary: function () {
       var ErrorView;
-      if (app.get('displayErrorSummary') && Forms.current.getInvalidElements) {
+      var currentForm = this.model.attributes.currentForm;
+      if (app.get('displayErrorSummary') && currentForm.getInvalidElements) {
         if (!this.errorSummary) {
           ErrorView = FormActionView.prepareErrorSummary();
-          this.errorSummary = new ErrorView({ model: Forms.current });
+          this.errorSummary = new ErrorView({ model: currentForm });
           // insert error summary above the form controls
           this.$errorSummaryContainer.append(this.errorSummary.render().$el);
           if (this.errorSummary.enhance) {
@@ -71,8 +72,16 @@ define(function (require) {
 
     render: function () {
       var view = this;
+      var Forms;
 
-      Forms.getDefinition(view.model.get('blinkFormObjectName'), view.model.get('blinkFormAction'))
+      loadForms()
+        .then(function (F) {
+          Forms = F;
+          return Forms.getDefinition(
+            view.model.get('blinkFormObjectName'),
+            view.model.get('blinkFormAction')
+          );
+        })
         .then(function (definition) {
           var formRecord;
           var pendingModel;

--- a/src/bic/view/form/error-summary-list.js
+++ b/src/bic/view/form/error-summary-list.js
@@ -4,7 +4,6 @@ define(function (require) {
   // foreign modules
 
   var Backbone = require('backbone');
-  var Forms = require('BlinkForms');
   var $ = require('jquery');
   var _ = require('underscore');
   var Mustache = require('mustache');
@@ -49,7 +48,8 @@ define(function (require) {
     },
 
     gotoField: function (e) {
-      return Forms.current.get('_view').goToElement($(e.target).attr('for'));
+      var currentForm = this.model.attributes.currentForm;
+      return currentForm.get('_view').goToElement($(e.target).attr('for'));
     },
 
     showLess: function () {

--- a/src/bic/view/interaction.js
+++ b/src/bic/view/interaction.js
@@ -17,7 +17,6 @@ define(function (require) {
     var inputPromptTemplate = require('text!bic/template/inputPrompt.mustache');
     var categoryTemplate = require('text!bic/template/category-list.mustache');
     var popupTemplate = require('text!bic/template/popup.mustache');
-    var FormView = require('bic/view/form');
     var app = require('bic/model/application');
     var StarModel = require('bic/model/star');
     var StarView = require('bic/view/star');
@@ -44,7 +43,8 @@ define(function (require) {
 
     InteractionView = Backbone.View.extend({
 
-      initialize: function () {
+      initialize: function (options) {
+        Backbone.View.prototype.initialize.call(this, options);
         $('body').append(this.$el);
         window.BMP.BIC.view = this;
       },
@@ -217,27 +217,6 @@ define(function (require) {
             }
           });
           this.model.performXSLT();
-        } else if (this.model.has('type') && this.model.get('type') === 'form') {
-          if ($('#ActiveFormContainer').length > 0) {
-            $('#ActiveFormContainer').attr('id', 'FormContainer');
-          }
-
-          // Form
-          view.$el.html(Mustache.render(Template, {
-            header: inheritedAttributes.header,
-            footer: inheritedAttributes.footer
-          }));
-
-          view.subView = new FormView({
-            model: view.model,
-            el: view.$el.children('[data-role="content"]')
-          });
-
-          view.listenToOnce(view.subView, 'render', function () {
-            view.trigger('render');
-          });
-
-          view.subView.render();
 
         } else if (this.model.id.toLowerCase() === window.BMP.BIC.siteVars.answerSpace.toLowerCase()) {
           // Home Screen

--- a/src/bic/view/interaction/form.js
+++ b/src/bic/view/interaction/form.js
@@ -51,8 +51,11 @@ define(function (require) {
       this.subView.render();
     },
 
-    destroy: function () {
-      InteractionView.prototype.destroy.apply(this, arguments);
+    remove: function () {
+      if (this.subView) {
+        this.subView.remove();
+      }
+      InteractionView.prototype.remove.apply(this, arguments);
     }
 
   });

--- a/src/bic/view/interaction/form.js
+++ b/src/bic/view/interaction/form.js
@@ -1,0 +1,59 @@
+define(function (require) {
+  'use strict';
+
+  // foreign modules
+
+  var $ = require('jquery');
+  var _ = require('underscore');
+  var Mustache = require('mustache');
+
+  // local modules
+
+  var FormView = require('bic/view/form');
+  var InteractionView = require('bic/view/interaction');
+  var Template = require('text!bic/template/interaction.mustache');
+
+  // this module
+
+  return InteractionView.extend({
+
+    initialize: function (options) {
+      InteractionView.prototype.initialize.call(this, options);
+    },
+
+    render: function () {
+      var inheritedAttributes = this.model.inherit({});
+
+      // Non-type specific
+      if (_.has(inheritedAttributes, 'themeSwatch')) {
+        this.$el.attr('data-theme', inheritedAttributes.themeSwatch);
+      }
+
+      if ($('#ActiveFormContainer').length > 0) {
+        $('#ActiveFormContainer').attr('id', 'FormContainer');
+      }
+
+      // Form
+      this.$el.html(Mustache.render(Template, {
+        header: inheritedAttributes.header,
+        footer: inheritedAttributes.footer
+      }));
+
+      this.subView = new FormView({
+        model: this.model,
+        el: this.$el.children('[data-role="content"]')
+      });
+
+      this.listenToOnce(this.subView, 'render', function () {
+        this.trigger('render');
+      }.bind(this));
+
+      this.subView.render();
+    },
+
+    destroy: function () {
+      InteractionView.prototype.destroy.apply(this, arguments);
+    }
+
+  });
+});

--- a/src/frag/10-start.frag
+++ b/src/frag/10-start.frag
@@ -7,7 +7,6 @@
             'underscore',
             'backbone',
             'mustache',
-            'BlinkForms',
             'jquerymobile',
             'BMP.Blobs',
             'modernizr',
@@ -19,5 +18,5 @@
     } else {
         root.bic = factory();
     }
-}(this, function (Promise, $, _, Backbone, Mustache, BlinkForms, jquerymobile, BMP, Modernizr, Pouch, pollUntil) {
+}(this, function (Promise, $, _, Backbone, Mustache, jquerymobile, BMP, Modernizr, Pouch, pollUntil) {
   window.pollUntil = pollUntil;

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -5,7 +5,9 @@
   },
   "globals": {
     "assert": true,
-    "requirejs": false
+    "expect": false,
+    "requirejs": false,
+    "sinon": true
   },
   "rules": {
     "accessor-pairs": 0,

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -71,6 +71,7 @@ require([
   'tests/unit/promise-blinkgap',
   'tests/unit/router',
   'tests/unit/view-interaction',
+  'tests/unit/view-interaction-form',
   'tests/unit/view-star',
   'tests/unit/view-form',
   'tests/unit/view-form-action',

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -9,6 +9,7 @@ require.config({
     feature: 'node_modules/amd-feature/feature',
     '@blinkmobile/geolocation': 'node_modules/@blinkmobile/geolocation/geolocation',
     '@jokeyrhyme/deadline': 'node_modules/@jokeyrhyme/deadline/dist/index',
+    '@jokeyrhyme/promised-requirejs': 'node_modules/@jokeyrhyme/promised-requirejs/dist/index',
     Squire: 'node_modules/squirejs/src/Squire',
     pollUntil: 'node_modules/poll-until/poll-until',
     mustache: 'node_modules/mustache/mustache',

--- a/tests/unit/model-interaction.js
+++ b/tests/unit/model-interaction.js
@@ -1,4 +1,4 @@
-define(['Squire', 'chai'], function (Squire, chai) {
+define(['Squire', 'chai', 'backbone'], function (Squire, chai, Backbone) {
   'use strict';
 
   var should = chai.should();
@@ -17,6 +17,8 @@ define(['Squire', 'chai'], function (Squire, chai) {
         subscribe: function () { console.log('#subscribe'); }
       });
       /*eslint-enable no-console*/
+
+      injector.mock('bic/view/interaction', Backbone.View);
 
       injector.require(['bic/model/interaction'], function (required) {
         Model = required;

--- a/tests/unit/router.js
+++ b/tests/unit/router.js
@@ -1,4 +1,6 @@
-define(['Squire', 'sinon', 'jquery', 'jquerymobile'], function (Squire, sinon, $, $mobile) {
+define([
+  'Squire', 'sinon', 'jquery', 'jquerymobile', 'backbone'
+], function (Squire, sinon, $, $mobile, Backbone) {
   'use strict';
 
   var CONTEXT = 'tests/unit/router.js';
@@ -59,9 +61,8 @@ define(['Squire', 'sinon', 'jquery', 'jquerymobile'], function (Squire, sinon, $
           get: function () {}
         }
       });
-      injector.mock('bic/view/interaction', {
-        render: function () { return null; }
-      });
+      injector.mock('bic/view/interaction', Backbone.View);
+      injector.mock('bic/view/interaction/form', Backbone.View);
       done();
 
     });

--- a/tests/unit/view-form-action.js
+++ b/tests/unit/view-form-action.js
@@ -28,6 +28,7 @@ define(['Squire', 'backbone', 'chai'], function (Squire, Backbone, chai) {
           getInvalidElements: function () {}
         }
       };
+      mockApp.attributes.currentForm = mockForms.current;
 
       mockApp.views = {
         FormControls: null
@@ -36,7 +37,10 @@ define(['Squire', 'backbone', 'chai'], function (Squire, Backbone, chai) {
       // import global `require('dep')` into local `injector.require('dep')`
       injector.mock('backbone', Backbone);
 
-      injector.mock('BlinkForms', mockForms);
+      injector.mock('bic/promise-forms', function () {
+        return Promise.resolve(mockForms);
+      });
+
       injector.mock('bic/model/application', mockApp);
       injector.mock('bic/view/form/controls', mockControls);
       injector.mock('bic/view/form/error-summary-list', MockErrorSummaryViewConstructor);

--- a/tests/unit/view-interaction-form.js
+++ b/tests/unit/view-interaction-form.js
@@ -9,6 +9,7 @@ define([
   describe('FormInteractionView - jQuery Mobile Implementation', function () {
     var injector, View;
     var FormView, FormActionView, FormControlsView;
+    var Forms;
     var interactionModel;
     var mockApp;
 
@@ -49,11 +50,13 @@ define([
       };
 
       injector.require([
+        'BlinkForms',
         'bic/view/interaction/form',
         'bic/view/form',
         'bic/view/form/action',
         'bic/view/form/controls'
-      ], function (FIV, FV, FAV, FCV) {
+      ], function (F, FIV, FV, FAV, FCV) {
+        Forms = F;
         View = FIV;
         FormView = FV;
         FormActionView = FAV;
@@ -104,6 +107,11 @@ define([
         assert(subView);
         assert.instanceOf(subView, FormControlsView);
         assert.equal(subView.model, interactionModel, 'sharing the same model');
+      });
+
+      it('establishes Forms.current === model.attributes.currentForm', function () {
+        assert.instanceOf(Forms.current, Backbone.Model);
+        assert.equal(Forms.current, view.model.attributes.currentForm);
       });
 
     });

--- a/tests/unit/view-interaction-form.js
+++ b/tests/unit/view-interaction-form.js
@@ -10,8 +10,7 @@ define([
     var injector, View;
     var FormView, FormActionView, FormControlsView;
     var Forms;
-    var interactionModel;
-    var mockApp;
+    var mockApp, mockForms, interactionModel;
 
     before(function (done) {
       var cfg = JSON.parse(JSON.stringify(requirejs.s.contexts._.config));
@@ -29,7 +28,7 @@ define([
       mockApp.hasStorage = function () { return false; };
       injector.mock('bic/model/application', mockApp);
 
-      injector.mock('BlinkForms', {
+      mockForms = {
         initialize: function () {
           var formModel = new Backbone.Model({ pages: new Backbone.Collection() });
           this.current = formModel;
@@ -38,6 +37,10 @@ define([
         getDefinition: function () {
           return Promise.resolve({ default: { name: 'test' } });
         }
+      };
+      injector.mock('BlinkForms', mockForms);
+      injector.mock('bic/promise-forms', function () {
+        return Promise.resolve(mockForms);
       });
 
       interactionModel = new Backbone.Model({

--- a/tests/unit/view-interaction-form.js
+++ b/tests/unit/view-interaction-form.js
@@ -1,0 +1,113 @@
+define([
+  'Squire', 'jquery', 'jquerymobile', 'chai', 'backbone'
+], function (Squire, $, $mobile, chai, Backbone) {
+  'use strict';
+
+  var CONTEXT = 'tests/unit/view/interaction-form.js';
+  var assert = chai.assert;
+
+  describe('FormInteractionView - jQuery Mobile Implementation', function () {
+    var injector, View;
+    var FormView, FormActionView, FormControlsView;
+    var interactionModel;
+    var mockApp;
+
+    before(function (done) {
+      var cfg = JSON.parse(JSON.stringify(requirejs.s.contexts._.config));
+      cfg.context = CONTEXT;
+      require.config(cfg);
+      injector = new Squire(CONTEXT);
+
+      // import global `require('dep')` into local `injector.require('dep')`
+      injector.mock('jquery', $);
+      injector.mock('jquerymobile', $mobile);
+      injector.mock('backbone', Backbone);
+
+      mockApp = new Backbone.Model();
+      mockApp.views = {};
+      mockApp.hasStorage = function () { return false; };
+      injector.mock('bic/model/application', mockApp);
+
+      injector.mock('BlinkForms', {
+        initialize: function () {
+          var formModel = new Backbone.Model({ pages: new Backbone.Collection() });
+          this.current = formModel;
+          return formModel;
+        },
+        getDefinition: function () {
+          return Promise.resolve({ default: { name: 'test' } });
+        }
+      });
+
+      interactionModel = new Backbone.Model({
+        blinkFormObjectName: 'test',
+        blinkFormAction: 'add'
+      });
+      interactionModel.getArgument = function () { return null; };
+      interactionModel.inherit = function () {
+        return this.attributes;
+      };
+
+      injector.require([
+        'bic/view/interaction/form',
+        'bic/view/form',
+        'bic/view/form/action',
+        'bic/view/form/controls'
+      ], function (FIV, FV, FAV, FCV) {
+        View = FIV;
+        FormView = FV;
+        FormActionView = FAV;
+        FormControlsView = FCV;
+        done();
+      });
+    });
+
+    after(function () {
+      injector.remove();
+    });
+
+    it('should be a Backbone.View object constructor', function () {
+      var view;
+      assert(View);
+      assert.isFunction(View);
+      view = new View({ model: interactionModel });
+      assert.instanceOf(view, View);
+      assert.instanceOf(view, Backbone.View);
+      assert.equal(view.model, interactionModel);
+    });
+
+    describe('constructed with a Model, then #render()', function () {
+      var view;
+
+      before(function (done) {
+        view = new View({ model: interactionModel });
+        view.once('render', done);
+        view.render();
+      });
+
+      it('has a "bic/view/form" subView', function () {
+        var subView = view.subView;
+        assert(subView);
+        assert.instanceOf(subView, FormView);
+        assert.equal(subView.model, interactionModel, 'sharing the same model');
+      });
+
+      it('has a "bic/view/form/action" subView.subView', function () {
+        var subView = view.subView.subView;
+        assert(subView);
+        assert.instanceOf(subView, FormActionView);
+        assert.equal(subView.model, interactionModel, 'sharing the same model');
+      });
+
+      it('has a "bic/view/form/controls" subView.subView.subView', function () {
+        var subView = view.subView.subView.subView;
+        assert(subView);
+        assert.instanceOf(subView, FormControlsView);
+        assert.equal(subView.model, interactionModel, 'sharing the same model');
+      });
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Other highlights:
- more as a proof-of-concept than anything else, extract Forms stuff out of InteractionView as its own sub-class
- `interactionModel&currentForm` is now a reference to `BMP.Forms.current` so fewer parts of the BIC actually need a direct AMD dependency upon Forms
- finally found a good home for the BIC's declaration of `BMP.Forms.getDefinition()` !!

For code review, I highly-recommend stepping through the individual commits one-by-one.