### PR TITLE
(chore) run ESLint directly, instead of via grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,12 +45,8 @@ module.exports = function (grunt) {
     watch: {
       src: {
         files: ['src/**/**', 'tests/**/**'],
-        tasks: ['build', 'eslint', 'karma:phantom']
+        tasks: ['build', 'karma:phantom']
       }
-    },
-
-    eslint: {
-      target: [ './' ]
     },
 
     karma: {
@@ -231,7 +227,6 @@ module.exports = function (grunt) {
 
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-eslint');
   grunt.loadNpmTasks('grunt-contrib-requirejs');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-concurrent');
@@ -240,7 +235,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-mustache-render');
   grunt.loadNpmTasks('grunt-text-replace');
 
-  grunt.registerTask('test', ['build', 'eslint', 'hapi:test', 'karma:phantom']);
+  grunt.registerTask('test', ['build', 'hapi:test', 'karma:phantom']);
 
   grunt.registerTask('build', ['replace', 'requirejs', 'copy:main', 'copy:dev', 'uglify', 'mustache_render']);
   grunt.registerTask('develop', ['concurrent']);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "grunt-contrib-requirejs": "~0.4",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "~0.6",
-    "grunt-eslint": "^17.0",
     "grunt-hapi": "^0.9.1",
     "grunt-karma": "^0.12.0",
     "grunt-mustache-render": "^1.9",
@@ -63,7 +62,9 @@
   },
   "scripts": {
     "build": "grunt build",
-    "test": "gulp test && grunt test"
+    "lint": "eslint .",
+    "test": "gulp test && grunt test",
+    "posttest": "npm run lint"
   },
   "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
- solves issues with old ESLint in grunt plugin