### PR TITLE
BIC-228 # Some Forms dont show client side errors

### DIFF
--- a/src/bic/view/form/action.js
+++ b/src/bic/view/form/action.js
@@ -23,7 +23,7 @@ define(function (require) {
     subView: null,
 
     initialize: function () {
-      this.model.on('showErrors', this.renderErrorSummary, this);
+      this.listenTo(this.model, 'showErrors', this.renderErrorSummary);
       this.$errorSummaryContainer = $('<div class="bm_errorsummary--container"></div>');
     },
 
@@ -133,6 +133,11 @@ define(function (require) {
       if (this.subView) {
         this.subView.remove();
       }
+
+      if (this.errorSummary) {
+        this.errorSummary.remove();
+      }
+
       Backbone.View.prototype.remove.apply(this, arguments);
     }
 

--- a/src/bic/view/form/error-summary-list.js
+++ b/src/bic/view/form/error-summary-list.js
@@ -19,6 +19,7 @@ define(function (require) {
   var FormsErrorSummaryListView = Backbone.View.extend({
     tagName: 'ul',
     className: 'bm-errorsummary',
+    isEnhanced: false,
 
     attributes: {
       'data-corners': 'true',
@@ -86,9 +87,9 @@ define(function (require) {
 
       this.$el.html(template);
 
-      /* eslint-disable no-unused-expressions */
-      this.$el.is(':visible') && this.$el.listview().listview('refresh');
-      /* eslint-enable no-unused-expressions */
+      if (this.$el.is(':visible')) {
+        this.enhance();
+      }
 
       this.trigger('render');
 
@@ -96,7 +97,12 @@ define(function (require) {
     },
 
     enhance: function () {
-      this.$el.listview().listview('refresh');
+      if (!this.isEnhanced) {
+        this.$el.listview();
+        this.isEnhanced = true;
+      }
+
+      this.$el.listview('refresh');
       return this;
     }
   }, {

--- a/tests/unit/view-error-summary-list.js
+++ b/tests/unit/view-error-summary-list.js
@@ -1,4 +1,4 @@
-define(['Squire', 'backbone', 'chai'], function (Squire, Backbone, chai) {
+define(['Squire', 'backbone', 'chai', 'sinon'], function (Squire, Backbone, chai, sinon) {
   'use strict';
 
   var CONTEXT = 'tests/unit/view/form/error-summary-list.js';
@@ -54,6 +54,17 @@ define(['Squire', 'backbone', 'chai'], function (Squire, Backbone, chai) {
     });
 
     describe('standard behavior', function () {
+      it('should not be flagged as enhanced', function () {
+        assert.isFalse(formActionView.isEnhanced);
+      });
+
+      it('should flag that it is enahnced after being enhanced', function () {
+        var stub = sinon.stub(formActionView.$el, 'listview');
+        formActionView.enhance();
+        assert.isTrue(formActionView.isEnhanced);
+        stub.restore();
+      });
+
       it('should default to 4 errors', function () {
         assert.equal(formActionView.getLimit(), 4);
       });


### PR DESCRIPTION
- change action view to use Backbone.View#listenTo
- Track status of enhancement in ErrorSummaryView

Problem was caused by the listener for a stale view still being in the models listener hash. no idea why I used `model#on` rather than `view#listenTo` :O