### PR TITLE
BIC 229 # BIC list view crashes when a Form doesnt have all Interaction actions generated

### DIFF
--- a/src/bic/collection/interactions.js
+++ b/src/bic/collection/interactions.js
@@ -1,6 +1,8 @@
 define(function (require) {
   'use strict';
 
+  var _ = require('underscore');
+
   // local modules
 
   var Collection = require('bic/collection');
@@ -18,7 +20,25 @@ define(function (require) {
       return Collection.prototype.datastore.call(this, NAME);
     },
 
-    comparator: 'order'
+    comparator: 'order',
+
+    /**
+     * returns a has of actions for the requested _formName_
+     * @param  {string} formName - The name of the form defined in the BMP
+     * @param {function} [transformer=_.identity] - A function to transform the data for formName. defaults to an identity function
+     * @return {Object}          - Keys are actions ('add', 'edit' etc), values are interactions run through the transformation function
+     */
+    getFormActions: function (formName, transformer) {
+      transformer = transformer || _.identity;
+
+      return this.reduce(function (formHash, interaction) {
+        if (interaction.get('blinkFormObjectName') === formName) {
+          formHash[interaction.get('blinkFormAction')] = transformer(interaction);
+        }
+
+        return formHash;
+      }, {});
+    }
 
   });
 

--- a/src/bic/view/form/list.js
+++ b/src/bic/view/form/list.js
@@ -17,14 +17,15 @@ define(function (require) {
   var FormListView = Backbone.View.extend({
     render: function () {
       var view = this;
+      var objectName = view.model.get('blinkFormObjectName');
 
-      app.formRecords.pull(view.model.get('blinkFormObjectName')).then(
+      app.formRecords.pull(objectName).then(
         function () {
           var BlinkForms = window.BMP.Forms;
           var templateData = {};
 
           templateData.headers = [];
-          BlinkForms.getDefinition(view.model.get('blinkFormObjectName'), view.model.get('blinkFormAction')).then(function (definition) {
+          BlinkForms.getDefinition(objectName, view.model.get('blinkFormAction')).then(function (definition) {
             var elements = [];
             _.each(definition._elements, function (value) {
               if (value.type !== 'subForm') {
@@ -49,19 +50,9 @@ define(function (require) {
             });
             templateData.hasContent = templateData.content.length > 0;
 
-            templateData.interactions = {};
-            templateData.interactions.edit = app.interactions.findWhere({
-              blinkFormObjectName: view.model.get('blinkFormObjectName'),
-              blinkFormAction: 'edit'
-            }).id;
-            templateData.interactions.view = app.interactions.findWhere({
-              blinkFormObjectName: view.model.get('blinkFormObjectName'),
-              blinkFormAction: 'view'
-            }).id;
-            templateData.interactions.delete = app.interactions.findWhere({
-              blinkFormObjectName: view.model.get('blinkFormObjectName'),
-              blinkFormAction: 'delete'
-            }).id;
+            templateData.interactions = app.interactions.getFormActions(objectName, function (interaction) {
+              return interaction.id;
+            });
 
             view.$el.html(Mustache.render(view.constructor.template, templateData));
             view.trigger('render');

--- a/tests/unit/collection-interactions.js
+++ b/tests/unit/collection-interactions.js
@@ -72,5 +72,36 @@ define(['Squire', 'backbone', 'sinon', 'chai'], function (Squire, Backbone, sino
     describe('#save', function () {
       it('should persist any models to the data store');
     });
+
+    describe('#getFormActions', function () {
+      var data = [
+        new Backbone.Model({blinkFormObjectName: 'a', blinkFormAction: 'add', extra: '1'}),
+        new Backbone.Model({blinkFormObjectName: 'a', blinkFormAction: 'edit', extra: '2'}),
+        new Backbone.Model({blinkFormObjectName: 'a', blinkFormAction: 'view', extra: '3'}),
+        new Backbone.Model({blinkFormObjectName: 'b', blinkFormAction: 'add', extra: '4'})
+      ];
+      var c;
+
+      before(function () {
+        c = new Collection(data);
+      });
+
+      it('should return 3 full records', function () {
+        var result = c.getFormActions('a');
+        assert.lengthOf(Object.keys(result), 3);
+        Object.keys(result).forEach(function (key, index) {
+          assert.deepEqual(result[key], data[index]);
+        });
+      });
+
+      it('should return 1 record with correct transform', function () {
+        var action = c.getFormActions('b', function (interaction) {
+          return 'it works!';
+        });
+
+        assert.lengthOf(Object.keys(action), 1);
+        assert.equal(action.add, 'it works!');
+      });
+    });
   });
 });


### PR DESCRIPTION
- Fixed problem where `_.findWhere()` returns `undefined`
- Refactorred to reduce amount of times arrays are iterated over
- Removed unneeded `elements` array

Still more work can be done on refactoring functions out of the views and into the collections/models, but I thought I'd leave that for another ticket to keep this pr small.