### PR TITLE
BIC-232 # Uncaught Type Error when accessing model.attributes.currentForm

### DIFF
--- a/src/bic/router.js
+++ b/src/bic/router.js
@@ -73,7 +73,7 @@ define(function (require) {
         // http://api.jquerymobile.com/1.3/pagebeforeload/
         // data.deferred.resolve|reject is expected after data.preventDefault()
         e.preventDefault();
-
+        Backbone.trigger('route:beforechange');
         // keep track of history depth for forms post-submission behaviour
         app.history.length += 1;
 

--- a/src/bic/view/form/action.js
+++ b/src/bic/view/form/action.js
@@ -48,9 +48,6 @@ define(function (require) {
         }
 
         this.errorSummary.render();
-        if (this.errorSummary.enhance) {
-          this.errorSummary.enhance();
-        }
         return this;
       }
     },
@@ -93,7 +90,7 @@ define(function (require) {
           view.renderControls();
 
           if (view.model.getArgument('id')) {
-            formRecord = app.formRecords.get(view.model.get('blinkFormObjectName') + '-' + view.model.get('args')['args[id]']);
+            formRecord = app.formRecords.get(view.model.get('blinkFormObjectName') + '-' + view.model.getArgument('id'));
             formRecord.populate(view.model.get('blinkFormAction'), function () {
               Forms.current.setRecord(formRecord.get('record'));
               view.trigger('render');
@@ -117,7 +114,7 @@ define(function (require) {
             view.trigger('render');
           }
         })
-        .then(null, function (err) {
+        .catch(function (err) {
           view.$el.append('<p>Error: unable to display this form. Try again later.</p>');
           view.trigger('render');
           c.error(err);

--- a/src/bic/view/interaction.js
+++ b/src/bic/view/interaction.js
@@ -44,6 +44,8 @@ define(function (require) {
   InteractionView = Backbone.View.extend({
 
     initialize: function (options) {
+      this.listenTo(Backbone, 'route:beforechange', this.destroy);
+
       Backbone.View.prototype.initialize.call(this, options);
       $('body').append(this.$el);
       window.BMP.BIC.view = this;
@@ -61,10 +63,7 @@ define(function (require) {
       'click [pending]': 'pendingQueue',
 
         // Form Actions
-      'click #queue': 'pendingQueue',
-
-        // Destroy
-      pageremove: 'destroy'
+      'click #queue': 'pendingQueue'
     },
 
     attributes: {
@@ -376,8 +375,10 @@ define(function (require) {
       });
     },
 
-    destroy: function () {
-      this.remove();
+    destroy: function (event) {
+      // remove backbone listeners but leave the DOM element for jQuery Mobile to clean
+      // up because jqm expects this.
+      this.stopListening();
     },
 
     processStars: function () {

--- a/tests/unit/view-interaction.js
+++ b/tests/unit/view-interaction.js
@@ -74,6 +74,12 @@ define([
         view = new View({});
       });
 
+      after(function () {
+        view.destroy();
+        view.$el.remove();
+        view = null;
+      });
+
       it('should have a home method', function () {
         expect(view.home).to.be.an.instanceOf(Function);
       });
@@ -113,6 +119,18 @@ define([
     });
 
     describe('events', function () {
+      var view;
+
+      before(function () {
+        view = new View({});
+      });
+
+      after(function () {
+        view.destroy();
+        view.$el.remove();
+        view = null;
+      });
+
       it('should handle click [keyword]');
       it('should handle click [interaction]');
       it('should handle click [category]');
@@ -120,6 +138,13 @@ define([
       it('should handle click [back]');
       it('should handle click [home]');
       it('should handle click [login]');
+
+      it('should listen for route:beforechange to clean up events but the element should be left in the DOM for jqm to clean up', function () {
+        var initialNumListeners = Object.keys(view._listeningTo).length;
+        Backbone.trigger('route:beforechange');
+        assert.isBelow(Object.keys(view._listeningTo || {}).length, initialNumListeners);
+        assert.isTrue($.contains(document, view.el));
+      });
     });
 
     describe('attributes', function () {


### PR DESCRIPTION
- Interaction view now listens for `route:beforechange` event to ensure
  cleanup of view happens on the old view, not the new one
- Interaction view no longer removes its element from the DOM as jqm
  expects to have control over its removal