### PR TITLE
BIC-242 # use new GZIP CDN

### DIFF
--- a/src/frag/00-config.js
+++ b/src/frag/00-config.js
@@ -11,7 +11,7 @@
     }
   };
 
-  cloudfront = '//d1c6dfkb81l78v.cloudfront.net/';
+  cloudfront = '//d2wxp0xv9nwmh.cloudfront.net/';
   filesystem = '/_c_/';
 
   if (typeof document !== 'undefined' && typeof location !== 'undefined') {

--- a/tests/commonjs/00_appcache.js
+++ b/tests/commonjs/00_appcache.js
@@ -49,7 +49,7 @@ test('AppCache CACHE items', function (t) {
     return assetPath.indexOf('{{') === -1;
   }).forEach(function (assetPath) {
     [
-      'https://d1c6dfkb81l78v.cloudfront.net/',
+      'https://d2wxp0xv9nwmh.cloudfront.net/',
       'https://d2wxp0xv9nwmh.cloudfront.net/'
     ].forEach(function (origin) {
       var assetUrl = assetPath.replace('/_c_/', origin);

--- a/tests/support/index.html
+++ b/tests/support/index.html
@@ -4,11 +4,11 @@
         <title>BIC-jQM</title>
         <meta name="viewport" content="initial-scale=1">
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        <link rel="stylesheet" href="//d1c6dfkb81l78v.cloudfront.net/pickadate/3.4.0/compressed/themes/default.css" />
-        <link rel="stylesheet" href="//d1c6dfkb81l78v.cloudfront.net/pickadate/3.4.0/compressed/themes/default.date.css" />
-        <link rel="stylesheet" href="//d1c6dfkb81l78v.cloudfront.net/pickadate/3.4.0/compressed/themes/default.time.css" />
-        <link rel="stylesheet" href="//d1c6dfkb81l78v.cloudfront.net/jquery.mobile/1.3.0/jqm.theme.min.css" />
-        <link rel="stylesheet" href="//d1c6dfkb81l78v.cloudfront.net/jquery.mobile/1.3.0/jqm.structure.min.css" />
+        <link rel="stylesheet" href="//d2wxp0xv9nwmh.cloudfront.net/pickadate/3.4.0/compressed/themes/default.css" />
+        <link rel="stylesheet" href="//d2wxp0xv9nwmh.cloudfront.net/pickadate/3.4.0/compressed/themes/default.date.css" />
+        <link rel="stylesheet" href="//d2wxp0xv9nwmh.cloudfront.net/pickadate/3.4.0/compressed/themes/default.time.css" />
+        <link rel="stylesheet" href="//d2wxp0xv9nwmh.cloudfront.net/jquery.mobile/1.3.0/jqm.theme.min.css" />
+        <link rel="stylesheet" href="//d2wxp0xv9nwmh.cloudfront.net/jquery.mobile/1.3.0/jqm.structure.min.css" />
         <style type="text/css">
           .blink-star-on, .blink-star-off { display: inline-block; margin: .1em; width: 32px; height: 32px; background-color: transparent; }
           .blink-star-on { background-image: url(/gfx/star-on32.png); }
@@ -35,8 +35,8 @@
     </head>
     <body>
         <div data-role="page" id="temp">Loading, please wait.</div>
-        <script src="//d1c6dfkb81l78v.cloudfront.net/blink/require/6/require.min.js"></script>
-        <!--<script src="//d1c6dfkb81l78v.cloudfront.net/blink/bic/3/1411018236186/bic.js"></script>-->
+        <script src="//d2wxp0xv9nwmh.cloudfront.net/blink/require/6/require.min.js"></script>
+        <!--<script src="//d2wxp0xv9nwmh.cloudfront.net/blink/bic/3/1411018236186/bic.js"></script>-->
         <script src="/integration/bic.js"></script>
     </body>
 </html>

--- a/tests/support/server.js
+++ b/tests/support/server.js
@@ -72,7 +72,7 @@ server.route({
     });
     contents = contents.replace('/_c_/blink/bic/{{id}}/bic.min.js\n', '');
     contents = contents.replace('/_c_/blink/bic/{{id}}/bic.js', '/bic.js');
-    contents = contents.replace(/^\/_c_\//mg, '//d1c6dfkb81l78v.cloudfront.net/');
+    contents = contents.replace(/^\/_c_\//mg, '//d2wxp0xv9nwmh.cloudfront.net/');
     contents += '\nCACHE:\n/_R_/common/3/xhr/GetConfig.php?_asn=' + request.query.answerSpace + '\n';
     reply(contents).header('Content-Type', 'text/cache-manifest');
   }

--- a/tests/support/template-data.js
+++ b/tests/support/template-data.js
@@ -26,7 +26,7 @@ var bicVersion = (function () {
 
 function getScriptsHTML (bic, config) {
   var html = bic.scripts.reduce(function (prev, current) {
-    var href = '//d1c6dfkb81l78v.cloudfront.net/' + current;
+    var href = '//d2wxp0xv9nwmh.cloudfront.net/' + current;
     if (current.indexOf('bic.min.js') !== -1) {
       return prev + '<script src="/bic.js"></script>';
     }
@@ -68,7 +68,7 @@ module.exports = function (BMP_HOST, req, callback) {
         env: {},
         env_json: '{}',
         styleSheets_html: bicVersion.styleSheets.theme.reduce(function (prev, current) {
-          var href = '//d1c6dfkb81l78v.cloudfront.net/' + current;
+          var href = '//d2wxp0xv9nwmh.cloudfront.net/' + current;
           return prev + '<link rel="stylesheet" href="' + href + '" />';
         }, ''),
         scripts_html: getScriptsHTML(bicVersion, body['a' + answerSpaceId]),


### PR DESCRIPTION
### Fixed

- BIC-242: use new GZIP CDN (same as BMP) (#61, @jokeyrhyme)

    - enables this and newer BIC versions on BMP 3.1.0 and newer to be used with the AppCache Fetcher

    - HelpDesk: 6296-QTAZ-4747