### PR TITLE
BIC-253 # increase IndexedDB test timeout to 5sec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 ## Unreleased
 
 
+### Fixed
+
+-   BIC-253: increase IndexedDB reliability test timeout to 5sec
+
+    -   better accommodates fluctuations in boot speed
+
+    -   HelpDesk: 1425-WDXM-4987
+
+
 ## 5.0.3 - 2017-02-22
 
 

--- a/src/bic/promise-indexeddb.js
+++ b/src/bic/promise-indexeddb.js
@@ -14,6 +14,8 @@ define(function (require) {
 
   // this module
 
+  var TIMEOUT = 5000;
+
   function isIt () {
     return new Promise(function (resolve) {
       isIndexedDBReliable.quick(function (result) {
@@ -23,12 +25,9 @@ define(function (require) {
   }
 
   return whenBlinkGapReady.then(function () {
-    // pick a time under 2sec, which is the default test timeout
-    return deadline.promise(isIt(), 1500).then(null, function () {
+    return deadline.promise(isIt(), TIMEOUT).then(null, function () {
       c.warn('timeout: IndexedDB tests too slow');
       return Promise.resolve();
     });
-    // timer should not be necessary for actual usage
-    // but timer _is_ mysteriously necessary for running the tests in Safari
   });
 });


### PR DESCRIPTION
### Fixed

-   BIC-253: increase IndexedDB reliability test timeout to 5sec

    -   better accommodates fluctuations in boot speed

    -   HelpDesk: 1425-WDXM-4987


### Notes

-   the original 1.5sec timeout was deliberately less than Mocha's default 2sec timeout

-   it seems that the browsers in which we execute tests all do so within Mocha's timeout now