### PR TITLE
BIC-254 # increase IndexedDB test timeout to 30sec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 ## Unreleased
 
 
+### Fixed
+
+-   BIC-253: increase IndexedDB reliability test timeout to 30sec
+
+    -   better accommodates fluctuations in boot speed
+
+    -   HelpDesk: 1425-WDXM-4987
+
+
 ## 5.0.4 - 2017-03-06
 
 

--- a/src/bic/promise-indexeddb.js
+++ b/src/bic/promise-indexeddb.js
@@ -14,7 +14,7 @@ define(function (require) {
 
   // this module
 
-  var TIMEOUT = 5000;
+  var TIMEOUT = 30 * 1000; // 30 seconds
 
   function isIt () {
     return new Promise(function (resolve) {


### PR DESCRIPTION
### Fixed

-   BIC-254: increase IndexedDB reliability test timeout to 30sec

    -   better accommodates fluctuations in boot speed

    -   HelpDesk: 1425-WDXM-4987